### PR TITLE
net-analyzer/nikto: fix config file could not find error.

### DIFF
--- a/net-analyzer/nikto/nikto-2.1.5-r3.ebuild
+++ b/net-analyzer/nikto/nikto-2.1.5-r3.ebuild
@@ -40,7 +40,7 @@ src_compile() {
 }
 
 src_install() {
-	insinto /etc/nikto
+	insinto /etc
 	doins nikto.conf
 
 	dobin nikto.pl replay.pl


### PR DESCRIPTION
Just found nikto can not run, and with this error:
```
- Could not find a valid nikto config file
```
The default config file is /etc/nikto.conf, but in this ebuild it installed to /etc/nikto/nikto.conf.