### PR TITLE
Prefer nmap with nse flag against lua flag in nmap_vulscan

### DIFF
--- a/net-analyzer/nmap_vulscan/nmap_vulscan-2.0.ebuild
+++ b/net-analyzer/nmap_vulscan/nmap_vulscan-2.0.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="amd64 x86 arm"
 
 DEPEND=""
-RDEPEND="|| ( net-analyzer/nmap[lua] net-analyzer/nmap[nse] )"
+RDEPEND="|| ( net-analyzer/nmap[nse] net-analyzer/nmap[lua] )"
 
 S="${WORKDIR}"
 


### PR DESCRIPTION
I don't know if it's just a paludis bug, but my package manager wants to downgrade to nmap 6.47 (when the lua flag was still there) so I had to change the order.