### PR TITLE
Added an ebuild for the current oclhashcat beta.

### DIFF
--- a/app-crypt/oclhashcat/oclhashcat-3.0.0_pre20160610.ebuild
+++ b/app-crypt/oclhashcat/oclhashcat-3.0.0_pre20160610.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+inherit git-2 autotools
+
+DESCRIPTION="An advanced GPU-based password recovery utility"
+HOMEPAGE="https://hashcat.net/oclhashcat/"
+EGIT_REPO_URI="https://github.com/hashcat/oclhashcat.git"
+EGIT_COMMIT="f30629b21a5350b205972e3e7a5dd62f683e15ad"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~x86 ~amd64"
+DEPEND="dev-util/intel-ocl-sdk"
+
+src_compile() {
+	export PREFIX=/usr
+	make
+}


### PR DESCRIPTION
This builds and installs fine for me, now that a couple of small
Makefile tweaks have been merged upstream.

Note, even though 3.0 is still in beta, I do not recommend trying an
ebuild for the 2.0x release sources.  The build environment in 3.0 has
improved hugely; ebuilds for building 2.0 from source are far more
painful.