### PR TITLE
Changed libscrypt dependency to libsodium for ext4-crypt

### DIFF
--- a/sys-fs/ext4-crypt/ext4-crypt-9999.ebuild
+++ b/sys-fs/ext4-crypt/ext4-crypt-9999.ebuild
@@ -18,6 +18,6 @@ KEYWORDS="~amd64 ~x86"
 
 DEPEND=""
 RDEPEND="${DEPEND}
-		app-crypt/libscrypt
+		dev-libs/libsodium
 		sys-apps/keyutils
 		"


### PR DESCRIPTION
upstream gdelugre/ext4-crypt replaced libscrypt by libsodium since Sep 25, 2016

