### PR TITLE
unicorn: force building internal qemu w/ python 2

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.1.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1.ebuild
@@ -17,7 +17,8 @@ IUSE_UNICORN_TARGETS="x86 m68k arm aarch64 mips sparc"
 use_unicorn_targets=$(printf ' unicorn_targets_%s' ${IUSE_UNICORN_TARGETS})
 IUSE+=" ${use_unicorn_targets}"
 
-DEPEND="dev-libs/glib:2"
+DEPEND="dev-libs/glib:2
+	dev-lang/python:2.7"
 RDEPEND="${DEPEND}
 	virtual/pkgconfig"
 
@@ -38,7 +39,7 @@ src_configure(){
 }
 
 src_compile() {
-	UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="no" ./make.sh
+	UNICORN_QEMU_FLAGS="--python=$(which python2.7)" UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="no" ./make.sh
 }
 
 src_install() {


### PR DESCRIPTION
I am running a stock (actually hardened) Gentoo setup w/ the Pentoo overlay added later; I did not use the Pentoo installer. I also haven't enabled the pentoo profile. This might be why I'm seeing issues other users aren't.

Unicorn comes with an included version of QEMU, and it's build breaks when Python 3 is used. This patch forces it to build w/ Python 2 and adds a build dependency.

Speaking of which, I noticed that in this package the run-time dependencies include pkg-config, and the build dependencies include glib. Is that a typo? Should we swap them?