### PR TITLE
dex2jar: fix install

### DIFF
--- a/dev-util/dex2jar/dex2jar-2.1_pre20150601.ebuild
+++ b/dev-util/dex2jar/dex2jar-2.1_pre20150601.ebuild
@@ -33,7 +33,7 @@ src_prepare() {
 src_install() {
 	dodir /opt/"${PN}"
 	cp -R "${S}"/* "${D}/opt/"${PN}"" || die "Install failed!"
-	for i in /opt/dex2jar/*.sh; do
+	for i in "${D}"/opt/dex2jar/*.sh; do
 		dosym ${i} /usr/bin/${i##*/}
 	done
 


### PR DESCRIPTION
dex2jar reinstalled fine (when files were already in place), but had
problems on fresh install.

This is because it attempted to glob over /opt/something/*, which resolved to the string "/opt/something/*" on a fresh install (because /opt/something didn't exist), but worked on systems that already had dex2jar installed. (See the patch.) Solution was to change it to "${D}/opt/something"/*.