### PR TITLE
h2: remove package in favor of in-tree ebuild

### DIFF
--- a/net-proxy/mitmproxy/mitmproxy-1.0.2-r1.ebuild
+++ b/net-proxy/mitmproxy/mitmproxy-1.0.2-r1.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	>=dev-python/cryptography-1.3[${PYTHON_USEDEP}] <dev-python/cryptography-1.8
 	>=dev-python/cssutils-1.0.1[${PYTHON_USEDEP}] <dev-python/cssutils-1.1
 	>=dev-python/flask-0.10.1[${PYTHON_USEDEP}] <dev-python/flask-0.12
-	>=dev-python/h2-2.5.1[${PYTHON_USEDEP}] <dev-python/h2-3
+	>=dev-python/hyper-h2-2.5.1[${PYTHON_USEDEP}] <dev-python/hyper-h2-3
 	>=dev-python/html2text-2016.1.8[${PYTHON_USEDEP}] <=dev-python/html2text-2016.9.19
 	>=dev-python/hyperframe-4.0.1[${PYTHON_USEDEP}] <dev-python/hyperframe-5
 	>=dev-python/jsbeautifier-1.6.3[${PYTHON_USEDEP}] <dev-python/jsbeautifier-1.7

--- a/net-proxy/mitmproxy/mitmproxy-2.0.2.ebuild
+++ b/net-proxy/mitmproxy/mitmproxy-2.0.2.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	>=dev-python/construct-2.8[${PYTHON_USEDEP}] <dev-python/construct-2.9
 	>=dev-python/cryptography-1.3[${PYTHON_USEDEP}] <dev-python/cryptography-1.9
 	>=dev-python/cssutils-1.0.1[${PYTHON_USEDEP}] <dev-python/cssutils-1.1
-	>=dev-python/h2-2.5.1[${PYTHON_USEDEP}] <dev-python/h2-3
+	>=dev-python/hyper-h2-2.5.1[${PYTHON_USEDEP}] <dev-python/hyper-h2-3
 	>=dev-python/html2text-2016.1.8[${PYTHON_USEDEP}] <=dev-python/html2text-2016.9.19
 	>=dev-python/hyperframe-4.0.1[${PYTHON_USEDEP}] <dev-python/hyperframe-5
 	>=dev-python/jsbeautifier-1.6.3[${PYTHON_USEDEP}] <dev-python/jsbeautifier-1.7

--- a/net-proxy/mitmproxy/mitmproxy-9999.ebuild
+++ b/net-proxy/mitmproxy/mitmproxy-9999.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	>=dev-python/click-6.2[${PYTHON_USEDEP}] <dev-python/click-7
 	>=dev-python/cryptography-1.4[${PYTHON_USEDEP}] <dev-python/cryptography-1.10
 	>=dev-python/cssutils-1.0.1[${PYTHON_USEDEP}] <dev-python/cssutils-1.1
-	>=dev-python/h2-3.0[${PYTHON_USEDEP}] <dev-python/h2-4
+	>=dev-python/hyper-h2-3.0[${PYTHON_USEDEP}] <dev-python/hyper-h2-4
 	>=dev-python/html2text-2016.1.8[${PYTHON_USEDEP}] <=dev-python/html2text-2016.9.19
 	>=dev-python/hyperframe-5.0[${PYTHON_USEDEP}] <dev-python/hyperframe-6
 	>=dev-python/jsbeautifier-1.6.3[${PYTHON_USEDEP}] <dev-python/jsbeautifier-1.7

--- a/net-wireless/wifi-pumpkin/wifi-pumpkin-0.8.4.ebuild
+++ b/net-wireless/wifi-pumpkin/wifi-pumpkin-0.8.4.ebuild
@@ -40,7 +40,7 @@ RDEPEND="${PYTHON_DEPS}
 	dev-python/pefile[${PYTHON_USEDEP}]
 	dev-python/capstone-python[${PYTHON_USEDEP}]
 	dev-python/hyperframe[${PYTHON_USEDEP}]
-	dev-python/h2[${PYTHON_USEDEP}]
+	dev-python/hyper-h2[${PYTHON_USEDEP}]
 	=net-proxy/mitmproxy-0.11*[${PYTHON_USEDEP}]
 
 	plugins? ( net-dns/dnsmasq

--- a/net-wireless/wifi-pumpkin/wifi-pumpkin-0.8.5.ebuild
+++ b/net-wireless/wifi-pumpkin/wifi-pumpkin-0.8.5.ebuild
@@ -39,7 +39,7 @@ RDEPEND="${PYTHON_DEPS}
 	dev-python/pefile[${PYTHON_USEDEP}]
 	dev-python/capstone-python[${PYTHON_USEDEP}]
 	dev-python/hyperframe[${PYTHON_USEDEP}]
-	dev-python/h2[${PYTHON_USEDEP}]
+	dev-python/hyper-h2[${PYTHON_USEDEP}]
 	=net-proxy/mitmproxy-0.11*[${PYTHON_USEDEP}]
 	virtual/python-scapy[${PYTHON_USEDEP}]
 	dev-python/scapy-http[${PYTHON_USEDEP}]

--- a/profiles/pentoo/base/package.accept_keywords/dev-python
+++ b/profiles/pentoo/base/package.accept_keywords/dev-python
@@ -90,7 +90,7 @@ dev-python/simplesoapy
 ~dev-python/ruamel-base-1.0.0
 ~dev-python/ruamel-yaml-0.13.7
 ~dev-python/protobuf-python-3.1.0
-~dev-python/h2-2.5.1
+~dev-python/hyper-h2-2.5.1
 ~dev-python/hyperframe-4.0.1
 ~dev-python/construct-2.8.10
 =dev-python/pyasn1-0.2*

--- a/profiles/updates/3Q-2017
+++ b/profiles/updates/3Q-2017
@@ -1,0 +1,1 @@
+move dev-python/h2 dev-python/hyper-h2


### PR DESCRIPTION
Since `dev-python/hyper-h2` has been in-tree for a while now, we should migrate stuff to that ebuild. This pull request puts in an update for the move and fixes dependencies for `net-proxy/mitmproxy` and `net-wireless/wifi-pumpkin`.