### PR TITLE
kaitaistruct: fix description and use preferred notation for SRC_URI

### DIFF
--- a/dev-python/kaitaistruct/kaitaistruct-0.6.ebuild
+++ b/dev-python/kaitaistruct/kaitaistruct-0.6.ebuild
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 python3_{4,5} )
 
 inherit distutils-r1
 
-DESCRIPTION="Kaitai Struct declarative parser generator for binary data"
+DESCRIPTION="Kaitai Struct runtime for Python"
 HOMEPAGE="http://kaitai.io/"
-SRC_URI="mirror://pypi/$(echo ${PN} | cut -c 1)/${PN}/${P}.tar.gz"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"

--- a/dev-python/kaitaistruct/kaitaistruct-0.7.ebuild
+++ b/dev-python/kaitaistruct/kaitaistruct-0.7.ebuild
@@ -7,9 +7,9 @@ PYTHON_COMPAT=( python2_7 python3_{4,5} )
 
 inherit distutils-r1
 
-DESCRIPTION="Kaitai Struct declarative parser generator for binary data"
+DESCRIPTION="Kaitai Struct runtime for Python"
 HOMEPAGE="http://kaitai.io/"
-SRC_URI="mirror://pypi/$(echo ${PN} | cut -c 1)/${PN}/${P}.tar.gz"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"


### PR DESCRIPTION
The Python package `kaitaistruct` is *not* the parser generator. In mitmproxy, the parser is already generated and this package provides the runtime library the generated parser requires. Additionally, the preferred notation for `SRC_URI` for PyPI is `mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz`. I updated the description to distinguish the package and updated the source uri.

Let me know if you would like for me to change anything else or have any questions.

Thanks for all of your work!