### PR TITLE
parseconfig: fix homepage, license, and lack of tests

### DIFF
--- a/dev-ruby/parseconfig/parseconfig-1.0.8.ebuild
+++ b/dev-ruby/parseconfig/parseconfig-1.0.8.ebuild
@@ -7,16 +7,14 @@ USE_RUBY="ruby22 ruby23 ruby24"
 
 RUBY_FAKEGEM_TASK_DOC=""
 RUBY_FAKEGEM_EXTRADOC="Changelog README.md"
-RUBY_FAKEGEM_RECIPE_TEST="rspec"
-#broken, not sure why
-RESTRICT="test"
+RUBY_FAKEGEM_RECIPE_TEST=""
 
 inherit ruby-fakegem
 
 DESCRIPTION="Provides simple parsing of standard *nix style config files."
-HOMEPAGE="https://github.com/derks/ruby-parseconfig"
+HOMEPAGE="https://github.com/datafolklabs/ruby-parseconfig"
 
-LICENSE="GPL-2"
+LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""


### PR DESCRIPTION
I'm not sure where you got that homepage and license, but this PR fixes those. Also, there are no distributed tests in the gem so we should indicate that.

Thanks for all of your work!