### PR TITLE
unicorn: fix multilib issue on install

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.1-r1.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-#inherit git-r3
+inherit multilib
 
 DESCRIPTION="A lightweight multi-platform, multi-architecture CPU emulator framework"
 HOMEPAGE="http://www.unicorn-engine.org"

--- a/dev-util/unicorn/unicorn-1.0.1-r1.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r1.ebuild
@@ -43,5 +43,5 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" UNICORN_STATIC="no" install
+	emake DESTDIR="${D}" LIBDIR="/usr$(get_libdir)" UNICORN_STATIC="no" install
 }


### PR DESCRIPTION
unicorn was failing emerge's multilib-strict check (after compile; before install) on my system, which means it was trying to put files into /usr/lib instead of /usr/lib32 or /usr/lib64.