### PR TITLE
unicorn: two tiny changes

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
@@ -3,7 +3,8 @@
 
 EAPI=6
 
-inherit multilib
+PYTHON_COMPAT=( python2_7 )
+inherit multilib python-any-r1
 
 DESCRIPTION="A lightweight multi-platform, multi-architecture CPU emulator framework"
 HOMEPAGE="http://www.unicorn-engine.org"
@@ -18,7 +19,7 @@ use_unicorn_targets=$(printf ' unicorn_targets_%s' ${IUSE_UNICORN_TARGETS})
 IUSE+=" ${use_unicorn_targets}"
 
 DEPEND="dev-libs/glib:2
-	dev-lang/python:2.7"
+	${PYTHON_DEPS}"
 RDEPEND="${DEPEND}
 	virtual/pkgconfig"
 
@@ -39,9 +40,9 @@ src_configure(){
 }
 
 src_compile() {
-	UNICORN_QEMU_FLAGS="--python=$(which python2.7)" UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="no" ./make.sh
+	UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="no" ./make.sh
 }
 
 src_install() {
-	emake DESTDIR="${D}" LIBDIR="/usr$(get_libdir)" UNICORN_STATIC="no" install
+	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" UNICORN_STATIC="no" install
 }

--- a/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=6
 
 PYTHON_COMPAT=( python2_7 )
-inherit multilib python-any-r1
+inherit multilib python-single-r1
 
 DESCRIPTION="A lightweight multi-platform, multi-architecture CPU emulator framework"
 HOMEPAGE="http://www.unicorn-engine.org"

--- a/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
@@ -40,9 +40,9 @@ src_configure(){
 }
 
 src_compile() {
-	UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="no" ./make.sh
+	UNICORN_ARCHS="${unicorn_targets}" ./make.sh
 }
 
 src_install() {
-	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" UNICORN_STATIC="no" install
+	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" install
 }


### PR DESCRIPTION
I "properly" fixed a hack I had done a few months ago, according to blshkv's advice: https://github.com/pentoo/pentoo-overlay/pull/187. I tested it and it builds properly even when the system python is 3.4.

Also, I added static libs; I don't see why these were not included in the first place since they're built by default w/ Unicorn.

Trying to squash PR's together now to not create overload. Although I do have one more major one coming for unicorn and unicorn-bindings, so I'll let that one wait.