### PR TITLE
unicorn: add static-libs use flag

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r2.ebuild
@@ -13,6 +13,7 @@ SRC_URI="https://github.com/unicorn-engine/unicorn/archive/${PV}.tar.gz -> ${P}.
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~m68k ~arm ~arm64 ~mips ~sparc"
+IUSE="static-libs"
 
 IUSE_UNICORN_TARGETS="x86 m68k arm aarch64 mips sparc"
 use_unicorn_targets=$(printf ' unicorn_targets_%s' ${IUSE_UNICORN_TARGETS})
@@ -40,9 +41,9 @@ src_configure(){
 }
 
 src_compile() {
-	UNICORN_ARCHS="${unicorn_targets}" ./make.sh
+	UNICORN_ARCHS="${unicorn_targets}" UNICORN_STATIC="$(use static-libs && echo yes || echo no)" ./make.sh
 }
 
 src_install() {
-	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" install
+	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" UNICORN_STATIC="$(use static-libs && echo yes || echo no)" install
 }

--- a/profiles/pentoo/arch/amd64/make.defaults
+++ b/profiles/pentoo/arch/amd64/make.defaults
@@ -6,4 +6,6 @@ FCFLAGS="${CFLAGS}"
 QEMU_SOFTMMU_TARGETS="arm aarch64 i386 x86_64"
 QEMU_USER_TARGETS="arm aarch64 i386 x86_64"
 
+UNICORN_TARGETS="arm aarch64 x86"
+
 GRUB_PLATFORMS="coreboot efi-32 efi-64 emu multiboot pc qemu"

--- a/profiles/pentoo/arch/amd64/make.defaults
+++ b/profiles/pentoo/arch/amd64/make.defaults
@@ -6,6 +6,4 @@ FCFLAGS="${CFLAGS}"
 QEMU_SOFTMMU_TARGETS="arm aarch64 i386 x86_64"
 QEMU_USER_TARGETS="arm aarch64 i386 x86_64"
 
-UNICORN_TARGETS="arm aarch64 x86"
-
 GRUB_PLATFORMS="coreboot efi-32 efi-64 emu multiboot pc qemu"


### PR DESCRIPTION
I went for static-libs, as this seems to be targeted at packages which install static libs alongside shared libs, which is what is happening here (see https://github.com/pentoo/pentoo-overlay/pull/231).