### PR TITLE
Revert "Revert "unicorn: add arm and aarch64 to base profile""

### DIFF
--- a/profiles/pentoo/arch/amd64/make.defaults
+++ b/profiles/pentoo/arch/amd64/make.defaults
@@ -6,4 +6,6 @@ FCFLAGS="${CFLAGS}"
 QEMU_SOFTMMU_TARGETS="arm aarch64 i386 x86_64"
 QEMU_USER_TARGETS="arm aarch64 i386 x86_64"
 
+UNICORN_TARGETS="arm aarch64 x86"
+
 GRUB_PLATFORMS="coreboot efi-32 efi-64 emu multiboot pc qemu"


### PR DESCRIPTION
I am really sorry for all the little commits, and now literally reverting a revert commit. Turns out the issue that I initially reverted 1982f3b8ded54e3849c07dc64f4519de423b12cb was caused by ccache being misconfigured on my machine, _not_ something that should affect other users.

Looking at the logs it looks like ZeroChaos is having some trouble today too, hah ;)

Let me know if you'd rather have me pile up changes into larger patches before submitting PR's.