### PR TITLE
profile: do not set a global unicorn target variable. It is already set in each respective arch

### DIFF
--- a/profiles/pentoo/arch/amd64/make.defaults
+++ b/profiles/pentoo/arch/amd64/make.defaults
@@ -6,6 +6,4 @@ FCFLAGS="${CFLAGS}"
 QEMU_SOFTMMU_TARGETS="arm aarch64 i386 x86_64"
 QEMU_USER_TARGETS="arm aarch64 i386 x86_64"
 
-UNICORN_TARGETS="arm aarch64 x86"
-
 GRUB_PLATFORMS="coreboot efi-32 efi-64 emu multiboot pc qemu"


### PR DESCRIPTION
Reverts pentoo/pentoo-overlay#233