### PR TITLE
unicorn: add python bindings

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.1-r3.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.1-r3.ebuild
@@ -3,8 +3,8 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 )
-inherit multilib python-single-r1
+PYTHON_COMPAT=( python2_7 python3_4 )
+inherit multilib distutils-r1
 
 DESCRIPTION="A lightweight multi-platform, multi-architecture CPU emulator framework"
 HOMEPAGE="http://www.unicorn-engine.org"
@@ -13,7 +13,7 @@ SRC_URI="https://github.com/unicorn-engine/unicorn/archive/${PV}.tar.gz -> ${P}.
 LICENSE="GPL-2"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~m68k ~arm ~arm64 ~mips ~sparc"
-IUSE="static-libs"
+IUSE="python static-libs"
 
 IUSE_UNICORN_TARGETS="x86 m68k arm aarch64 mips sparc"
 use_unicorn_targets=$(printf ' unicorn_targets_%s' ${IUSE_UNICORN_TARGETS})
@@ -46,4 +46,17 @@ src_compile() {
 
 src_install() {
 	emake DESTDIR="${D}" LIBDIR="/usr/$(get_libdir)" UNICORN_STATIC="$(use static-libs && echo yes || echo no)" install
+
+	if use python
+	then
+		cd bindings/python
+		if use python_targets_python2_7
+		then
+			emake DESTDIR="${D}" install
+		fi
+		if use python_targets_python3_4
+		then
+			emake DESTDIR="${D}" install3
+		fi
+	fi
 }


### PR DESCRIPTION
The unicorn-bindings package has some problems: first the ebuild breaks when trying to install some of the non-Python bindings (which no packages in Pentoo depend on anyway), and second, installing the unicorn-bindings packages causes the entire Unicorn shared library to be rebuild, except that this build does not respect UNICORN_TARGETS. So as a fix, I simply added a python use flag to the unicorn ebuild, which will install the python bindings during the install. This avoids rebuilding all of Unicorn. If this is acceptable, we could potentially move forward w/ unicorn-bindings[python] being a simple wrapper for unicorn[python], if it's needed for backward-compatability.