### PR TITLE
python-ntlm: fix description, use flags, and dependencies

### DIFF
--- a/dev-python/python-ntlm/python-ntlm-1.1.0-r1.ebuild
+++ b/dev-python/python-ntlm/python-ntlm-1.1.0-r1.ebuild
@@ -1,29 +1,27 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
-EAPI=5
+EAPI=6
 
 PYTHON_COMPAT=( python{2_6,2_7} )
 
 inherit distutils-r1
 
-DESCRIPTION="Clamd is a python interface to Clamd (Clamav daemon)"
+DESCRIPTION="Python library for NTLM support"
 HOMEPAGE="https://github.com/mullender/python-ntlm"
 SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
 
 LICENSE="LGPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-IUSE="example"
+IUSE="examples"
 
-RDEPEND=""
-DEPEND="${RDEPEND}
-	dev-python/setuptools[${PYTHON_USEDEP}]"
+DEPEND=""
+RDEPEND="${DEPEND}"
 
 src_install() {
 	python_foreach_impl distutils-r1_python_install || die
-	if ! use example ; then
+	if ! use examples ; then
 		rm -r "${D}"/usr/bin/ || die
 		rm -r "${D}"/usr/lib/python-exec || die
 	fi


### PR DESCRIPTION
This package needs a proper description as well as a fix where the correct flag for examples is USE=examples (https://packages.gentoo.org/useflags/examples).