### PR TITLE
Update pentoo-system-2018.0-r8.ebuild

### DIFF
--- a/pentoo/pentoo-system/pentoo-system-2018.0-r8.ebuild
+++ b/pentoo/pentoo-system/pentoo-system-2018.0-r8.ebuild
@@ -43,7 +43,7 @@ PDEPEND="${PDEPEND}
 	|| ( sys-process/fcron virtual/cron )
 	sys-apps/gptfdisk
 	sys-apps/pcmciautils
-	!arm? ( !livecd-stage1? ( sys-kernel/genkernel
+	!arm? ( !livecd-stage1? ( || ( sys-kernel/genkernel sys-kernel/genkernel-next )
 		|| ( sys-boot/grub:2 sys-boot/grub:0 sys-boot/grub-static sys-boot/systemd-boot )
 		)
 		sys-boot/os-prober


### PR DESCRIPTION
sys-kernel/genkernel-next , adds a few features over reg genkernel , plymouth, at onepoint dracut ,  etc.. UEFI w/o pulling teeth    , allows either  to be used for now  https://bugs.gentoo.org/468942   features should be backported into genkernel... someday...  :-)
 a few genkernel wrappers use it , ie @sakaki- 's https://github.com/sakaki-/buildkernel for UEFI , also slightly useful for experimental porting of Pentoo to RPI3 or other arm/ amr64 boards. 
 