### PR TITLE
Create nassl-1.1.3.ebuild

### DIFF
--- a/dev-python/nassl/nassl-1.1.3.ebuild
+++ b/dev-python/nassl/nassl-1.1.3.ebuild
@@ -1,0 +1,30 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+inherit  distutils-r1 flag-o-matic
+
+DESCRIPTION="Experimental Python wrapper for OpenSSL"
+HOMEPAGE="https://github.com/nabla-c0d3/nassl"
+#SRC_URI="https://github.com/nabla-c0d3/nassl/archive/${PV}.tar.gz -> ${P}.tar.gz"
+SRC_URI="http://dev.pentoo.ch/~blshkv/distfiles/${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE=""
+
+#typing; python_version < '3.5'
+#enum34; python_version < '3.4'
+RDEPEND=""
+DEPEND="${RDEPEND}
+	dev-python/setuptools[${PYTHON_USEDEP}]"
+  #dev-python/pipenv
+
+distutils-r1_python_compile() {
+	append-cflags -fno-strict-aliasing
+	append-ldflags -Wl,-z,noexecstack
+	esetup.py build
+}


### PR DESCRIPTION
arm64 build failed , going to install the extradep. and hear's  a bump... uses pipeenv to build c+ extensions , 

[ebuild  N    *] dev-python/pipenv-9.0.0-r1 

trying again...
Linux scw-89ba37 4.9.93-mainline-rev1 #1 SMP Tue Apr 10 09:54:46 UTC 2018 aarch64 GNU/Linux
scw-89ba37  # USE="-lua gnome java minipentoo sourcefirelinux-smp-stats" emerge pentoo/pentoo-analyzer most are built.. but for this... 

tries to build openssl static in a can opening bug on dev..  however enjoy bump...