### PR TITLE
accept_keywords: open-vm-tools needs xml-security-c

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/app-emulation
+++ b/profiles/pentoo/base/package.accept_keywords/app-emulation
@@ -1,5 +1,7 @@
 app-emulation/open-vm-tools
 app-emulation/open-vm-tools-kmod
+# required by app-emulation/open-vm-tools
+dev-libs/xml-security-c
 
 ~app-emulation/virtualbox-additions-5.1.38
 ~app-emulation/virtualbox-modules-5.1.38


### PR DESCRIPTION
On amd64 hardened, after pentoo-installer from 2018 rc7.1, portage is synced.
When trying to update world with:
> emerge --deep --update --newuse world -vta

this is one of the errors:
> app-emulation/open-vm-tools:0
> 
>   selected: (app-emulation/open-vm-tools-10.1.15:0/0::gentoo, installed)
>   skipped: (app-emulation/open-vm-tools-10.2.5:0/0::gentoo, ebuild scheduled for merge) (see unsatisfied dependency below)
> 
> !!! All ebuilds that could satisfy "dev-libs/xml-security-c" have been masked.
> !!! One of the following masked packages is required to complete your request:
> - dev-libs/xml-security-c-1.7.3::gentoo (masked by: ~amd64 keyword)
> 
> (dependency required by "app-emulation/open-vm-tools-10.2.5::gentoo[vgauth,xml-security-c]" [ebuild])
> For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.

app-emulation/open-vm-tools-10.1.15 is installed already from the ISO.

app-emulation/open-vm-tools itself has ~amd64, which is accepted in:
profiles/pentoo/base/package.accept_keywords/app-emulation
so I propose we accept dev-libs/xml-security-c in the same file.
Works here!

