### PR TITLE
accept_keywords: gnuradio needs codec2

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/media-libs
+++ b/profiles/pentoo/base/package.accept_keywords/media-libs
@@ -3,3 +3,6 @@
 
 #gpd pocket requires at least 1.1.5 but most of my testing was with 1.1.6
 ~media-libs/alsa-lib-1.1.6
+
+# required by net-wireless/gnuradio-3.7.13.3-r1::gentoo[vocoder]
+media-libs/codec2


### PR DESCRIPTION
On amd64 hardened, after pentoo-installer from 2018 rc7.1, portage is synced.
When trying to update world with:
> emerge --deep --update --newuse world -vta

this is one of the errors:
> !!! The following update has been skipped due to unsatisfied dependencies:
> 
> net-wireless/gnuradio:0
> 
>   selected: (net-wireless/gnuradio-3.7.11-r3:0/3.7.11::gentoo, ebuild scheduled for merge)
>   skipped: (net-wireless/gnuradio-3.7.13.3-r1:0/3.7.13.3::gentoo, ebuild scheduled for merge) (see unsatisfied dependency below)
> 
> !!! All ebuilds that could satisfy ">=media-libs/codec2-0.8.1" have been masked.
> !!! One of the following masked packages is required to complete your request:
> - media-libs/codec2-0.8.1::gentoo (masked by: ~amd64 keyword)
> 
> (dependency required by "net-wireless/gnuradio-3.7.13.3-r1::gentoo[vocoder]" [ebuild])
