### PR TITLE
Update qt to 5.9.6: Change accept_keywords

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/dev-qt
+++ b/profiles/pentoo/base/package.accept_keywords/dev-qt
@@ -1,5 +1,1 @@
-~dev-qt/qtwidgets-5.4.2
-~dev-qt/qtgui-5.4.2
-~dev-qt/qtcore-5.4.2
-~dev-qt/qtdbus-5.4.2
-~dev-qt/qtcharts-5.9.4
+~dev-qt/qtcharts-5.9.6


### PR DESCRIPTION
qt 5.9.6 is stable in Gentoo, but causes blocked packages in Pentoo. The
reason is dev-qt/qtcharts, all other qt 5.9.6 packages, that we use, are stable in
Gentoo.

Updated accept_packages/dev-qt: Update version of qtcharts, remove all
other packages because they are stable in Gentoo.

Tested on 2018 rc 7.2