### PR TITLE
Fix pentoo.conf: use pentoo-keyring.asc

### DIFF
--- a/pentoo/pentoo-system/files/pentoo.conf
+++ b/pentoo/pentoo-system/files/pentoo.conf
@@ -3,5 +3,5 @@ location = /var/db/repos/pentoo
 sync-uri = https://github.com/pentoo/pentoo-overlay.git
 sync-type = git
 sync-git-verify-commit-signature = true
-sync-openpgp-key-path = /usr/share/pentoo/pentoo.asc
+sync-openpgp-key-path = /usr/share/pentoo/pentoo-keyring.asc
 auto-sync = yes


### PR DESCRIPTION
Fix for FileNotFoundError: [Errno 2] No such file or directory: '/usr/share/pentoo/pentoo.asc'