### PR TITLE
Accept keyword for pentoo-installer

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/pentoo
+++ b/profiles/pentoo/base/package.accept_keywords/pentoo
@@ -12,5 +12,5 @@ pentoo/pentoo-mitm
 pentoo/pentoo-scanner
 pentoo/pentoo-rce
 pentoo/pentoo-wireless
-pentoo/pentoo-installer
+pentoo/pentoo-installer **
 pentoo/pentoo-voip


### PR DESCRIPTION
Users should update the installer before using it.
This commit masked it: e7e21d7ee710264ccb38c72c4eb9dd4f120ee7fd
and installer cannot be updated at the moment.