### PR TITLE
app-crypt/yubioath-desktop: rename .desktop file

### DIFF
--- a/app-crypt/yubioath-desktop/yubioath-desktop-4.3.4-r1.ebuild
+++ b/app-crypt/yubioath-desktop/yubioath-desktop-4.3.4-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+inherit qmake-utils eutils
+
+DESCRIPTION="Library and tool for personalization of Yubico's YubiKey NEO"
+HOMEPAGE="http://opensource.yubico.com/yubioath-desktop"
+#https://github.com/Yubico/yubioath-desktop/issues/254
+SRC_URI="https://github.com/Yubico/yubioath-desktop/releases/download/${P}/${P}.tar.gz -> ${P}.tar"
+
+KEYWORDS="~amd64"
+SLOT="4"
+LICENSE="BSD-2"
+
+RDEPEND="dev-qt/qtsingleapplication
+	dev-python/pyotherside"
+DEPEND="${RDEPEND}
+	>=app-crypt/yubikey-manager-0.5
+	dev-qt/qtdeclarative"
+
+#upstream is not consistent with this
+S=${WORKDIR}/${PN}
+
+#src_prepare() {
+	#https://github.com/Yubico/yubioath-desktop/pull/207
+#	epatch "${FILESDIR}/4.3-qtsingleapp.patch"
+#	eapply_user
+#}
+
+src_configure() {
+	eqmake5 yubioath-desktop.pro
+	python build_qrc.py resources.json
+}
+
+src_install() {
+	emake install INSTALL_ROOT="${D}"
+#    python_optimize  # does all packages by default
+	domenu resources/yubioath-desktop.desktop
+	doicon resources/icons/yubioath.png
+
+	emake compiler_rcc_make_all
+	emake compiler_buildqrc_make_all
+	emake compiler_moc_header_make_all
+}


### PR DESCRIPTION
Package currently fails to build. Change happened upstream 1 year ago:
https://github.com/Yubico/yubioath-desktop/commit/2add28eb317b1dff909fd7691e81d6e8f0dc7881

Only change is the line:

> domenu resources/yubioath-desktop.desktop