### PR TITLE
Move sourceforge svn repos

### DIFF
--- a/app-crypt/cryptohaze-combined/cryptohaze-combined-1.31.ebuild
+++ b/app-crypt/cryptohaze-combined/cryptohaze-combined-1.31.ebuild
@@ -21,7 +21,8 @@ RDEPEND="${DEPEND}"
 if [[ ${PV} == "9999" ]] ; then
 	inherit subversion
 	KEYWORDS="-*"
-	ESVN_REPO_URI="https://cryptohaze.svn.sourceforge.net/svnroot/cryptohaze/Cryptohaze-Combined"
+	# ESVN_REPO_URI="https://cryptohaze.svn.sourceforge.net/svnroot/cryptohaze/Cryptohaze-Combined"
+	ESVN_REPO_URI="https://svn.code.sf.net/p/cryptohaze/code/Cryptohaze-Combined"
 else
 	KEYWORDS="amd64 x86"
 	MY_PV=${PV/\./_}

--- a/app-crypt/cryptohaze-combined/cryptohaze-combined-9999.ebuild
+++ b/app-crypt/cryptohaze-combined/cryptohaze-combined-9999.ebuild
@@ -31,7 +31,8 @@ RDEPEND="${DEPEND}"
 if [[ ${PV} == "9999" ]] ; then
 	inherit subversion
 	KEYWORDS=""
-	ESVN_REPO_URI="https://cryptohaze.svn.sourceforge.net/svnroot/cryptohaze/Cryptohaze-Combined"
+	# ESVN_REPO_URI="https://cryptohaze.svn.sourceforge.net/svnroot/cryptohaze/Cryptohaze-Combined"
+	ESVN_REPO_URI="https://svn.code.sf.net/p/cryptohaze/code/Cryptohaze-Combined"
 else
 	KEYWORDS="~amd64 ~x86"
 	MY_PV=${PV/\./_}

--- a/dev-util/collabreate/collabreate-0.4.0_p20140528.ebuild
+++ b/dev-util/collabreate/collabreate-0.4.0_p20140528.ebuild
@@ -1,6 +1,5 @@
 # Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Header: /var/cvsroot/gentoo-x86/dev-util/radare/radare-1.5-r1.ebuild,v 1.2 2010/09/25 15:18:56 eva Exp $
 
 EAPI=6
 
@@ -8,8 +7,8 @@ inherit subversion
 
 DESCRIPTION="A plugin for IDA Pro designed to provide collaborative reverse engineering"
 HOMEPAGE="http://www.idabook.com/collabreate/"
-ESVN_REPO_URI="https://collabreate.svn.sourceforge.net/svnroot/collabreate/trunk@20"
-#SRC_URI="mirror://sourceforge/${PN}/${P}.tgz"
+ESVN_REPO_URI="https://svn.code.sf.net/p/collabreate/code/trunk@20"
+# ESVN_REPO_URI="https://collabreate.svn.sourceforge.net/svnroot/collabreate/trunk@20"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
'svn.sourceforge.net' is no longer available, the svn repos are now in:
https://svn.code.sf.net/p/...

This PR fixes the 2 packages that used 'svn.sourceforge.net.