### PR TITLE
fixing sonarqube's stop() function

### DIFF
--- a/dev-util/sonarqube-bin/files/sonar.init
+++ b/dev-util/sonarqube-bin/files/sonar.init
@@ -8,22 +8,18 @@ depend() {
 
 run_dir="/opt/sonar"
 command="/opt/sonar/bin/linux-multiarch.sh"
-pidfile="$run_dir/sonarr.pid"
 etc_dir="/etc/sonarqube"
-log_dir="/var/log/sonarqube"
-log_file="sonarr.log"
 
 start() {
 	ebegin "Starting SonarQube"
 
-        start-stop-daemon --start --background --make-pidfile --pidfile ${pidfile} \
-		-u ${USER} -g ${GROUP} --exec ${command} -- --daemon \
-		--log=${log_dir}/${log_file}
+        start-stop-daemon --start --background -u ${USER} -g ${GROUP} \
+		--exec ${command} -- --daemon
         eend $?
 }
 
 stop() {
         ebegin "Stopping SonarQube"
-        start-stop-daemon --stop --pidfile ${pidfile} --retry 15
+        start-stop-daemon --stop --name wrapper --retry 15
         eend $?
 }


### PR DESCRIPTION
The init file's stop() function didn't work and SonarQube continued to run in the background. This happens because the script that is launched, launches another wrapper that spawns SonarQube according to the system's arch (32/64 bit). I'm not sure how to solve this using a pidfile, and instead worked around it using `--name`. It's less elegant this way, I admit, but if anyone has a more elegant solution, please share.

Also, no logging was happening and I decided to remove this from the init file as well.