### PR TITLE
app-exploits/dirtycow: new package

### DIFF
--- a/app-exploits/dirtycow/dirtycow-9999.ebuild
+++ b/app-exploits/dirtycow/dirtycow-9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+EGIT_REPO_URI="https://github.com/dirtycow/dirtycow.github.io"
+EGIT_COMMIT="d71fe00954ac38c3f41c6d635e1d557febcfbfeb"
+
+inherit git-r3 toolchain-funcs
+
+DESCRIPTION="A privilege escalation vulnerability in the Linux Kernel"
+HOMEPAGE="https://dirtycow.ninja"
+
+LICENSE="CC0-1.0"
+SLOT="0"
+KEYWORDS="~amd64 ~arm64"
+
+MY_PN="dirtyc0w"
+#S="${WORKDIR}"
+
+src_compile() {
+	ebegin "$(tc-getCC) ${LDFLAGS} ${CFLAGS} -pthread -o ${PN} ${MY_PN}.c"
+	$(tc-getCC) ${LDFLAGS} ${CFLAGS} -pthread -o ${PN} ${MY_PN}.c || die
+	eend $?
+}
+
+src_install() {
+	dobin "${PN}"
+}


### PR DESCRIPTION
Dirty COW (CVE-2016-5195) is a privilege escalation vulnerability in the Linux Kernel

https://dirtycow.ninja