### PR TITLE
fixing maxminddb dep for dirhunt

### DIFF
--- a/dev-python/maxminddb/maxminddb-1.4.1-r1.ebuild
+++ b/dev-python/maxminddb/maxminddb-1.4.1-r1.ebuild
@@ -18,7 +18,7 @@ SLOT="0"
 KEYWORDS="amd64 ~ia64 ~ppc ~sparc x86 ~x86-fbsd"
 IUSE=""
 
-RDEPEND="dev-python/ipaddress[${PYTHON_USEDEP}]"
+RDEPEND="virtual/python-ipaddress[${PYTHON_USEDEP}]"
 DEPEND="
 	${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]


### PR DESCRIPTION
Fixed dep in order to avoid the following message:

```
emerge: there are no ebuilds built with USE flags to satisfy "dev-python/ipaddress[python_targets_pypy(-)?,python_targets_pypy3(-)?,python_targets_python2_7(-)?,python_targets_python3_4(-)?,python_targets_python3_5(-)?,python_targets_python3_6(-)?,-python_single_target_pypy(-),-python_single_target_pypy3(-),-python_single_target_python2_7(-),-python_single_target_python3_4(-),-python_single_target_python3_5(-),-python_single_target_python3_6(-)]".
!!! One of the following packages is required to complete your request:
- dev-python/maxminddb-1.4.1::pentoo (Change USE: -python_targets_python3_6)
(dependency required by "dev-python/maxminddb-1.4.1::pentoo" [ebuild])
(dependency required by "dev-python/maxminddb" [argument])
```

