### PR TITLE
=dev-python/service_identity-18.1.0: add python3_7 and pypy{,3} compat

### DIFF
--- a/dev-python/service_identity/service_identity-18.1.0.ebuild
+++ b/dev-python/service_identity/service_identity-18.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-PYTHON_COMPAT=( python2_7 python3_{4,5,6} )
+PYTHON_COMPAT=( python2_7 python3_{4,5,6,7} pypy{,3} )
 inherit distutils-r1
 
 DESCRIPTION="Service identity verification for pyOpenSSL."


### PR DESCRIPTION
https://service-identity.readthedocs.io/en/stable/installation.html
> Python 2.7, 3.4 and later, as well as PyPy are supported.