### PR TITLE
smbmap: fix dep and urls

### DIFF
--- a/net-analyzer/smbmap/smbmap-1.1.0-r1.ebuild
+++ b/net-analyzer/smbmap/smbmap-1.1.0-r1.ebuild
@@ -4,28 +4,27 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7} )
-EGO_PN=github.com/ShawnDEvans/${PN}
 
 inherit python-r1
 
 if [[ ${PV} = *9999* ]]; then
 	inherit git-r3
-	EGIT_REPO_URI="https://github.com/madengr/ham2mon.git"
+	EGIT_REPO_URI="https://github.com/ShawnDEvans/smbmap.git"
 	KEYWORDS=""
 else
 	KEYWORDS="~amd64 ~x86"
 	EGIT_COMMIT="${PV}"
-	SRC_URI="https://${EGO_PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
+	SRC_URI="https://github.com/ShawnDEvans/${PN}/archive/${EGIT_COMMIT}.tar.gz -> ${P}.tar.gz"
 fi
 
-DESCRIPTION="SMBMap is a handy SMB enumeration tool."
+DESCRIPTION="SMBMap is a handy SMB enumeration tool"
 HOMEPAGE="https://github.com/ShawnDEvans/smbmap"
 
 LICENSE="GPL-3"
 SLOT="0"
 IUSE=""
 
-RDEPEND=">=dev-python/impacket-0.9.20[${PYTHON_USEDEP}]
+RDEPEND=">=dev-python/impacket-0.9.20
 	dev-python/pyasn1[${PYTHON_USEDEP}]
 	dev-python/pycryptodomex[${PYTHON_USEDEP}]"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
Fixed dep to avoid having the following issue when trying to update world:

```
emerge: there are no ebuilds built with USE flags to satisfy ">=dev-python/impacket-0.9.20[python_targets_python3_6(-)?,python_targets_python3_7(-)?,-python_single_target_python3_6(-),-python_single_target_python3_7(-)]".
!!! One of the following packages is required to complete your request:
- net-analyzer/smbmap-1.1.0::pentoo (Change USE: -python_targets_python3_6)
(dependency required by "net-analyzer/smbmap-1.1.0::pentoo" [ebuild])
(dependency required by "@selected" [set])
(dependency required by "@world" [argument])
```

Also fixed URLs and removed the EGO_PN, which is part of the golang eclasses