### PR TITLE
keywords: adding missing keywords

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/app-crypt
+++ b/profiles/pentoo/base/package.accept_keywords/app-crypt
@@ -11,6 +11,8 @@ app-crypt/steghide
 
 app-crypt/asleap
 
+~app-crypt/hashid-3.1.4
+
 #Gentoo
 
 =app-crypt/yubikey-manager-qt-1.1* ~amd64

--- a/profiles/pentoo/base/package.accept_keywords/dev-go
+++ b/profiles/pentoo/base/package.accept_keywords/dev-go
@@ -29,3 +29,6 @@ dev-go/robotstxt-go
 # required by net-analyzer/gobuster
 dev-go/pflag
 dev-go/cobra
+
+# required by net-analyzer/aquatone
+~dev-go/go-sys-0_pre20180816

--- a/profiles/pentoo/base/package.accept_keywords/dev-vcs
+++ b/profiles/pentoo/base/package.accept_keywords/dev-vcs
@@ -1,1 +1,2 @@
 =dev-vcs/git-lfs-2.0*
+~dev-vcs/gitleaks-2.1.0-r1

--- a/profiles/pentoo/base/package.accept_keywords/net-analyzer
+++ b/profiles/pentoo/base/package.accept_keywords/net-analyzer
@@ -1,6 +1,7 @@
 ### Pentoo ###
 =net-analyzer/theHarvester-3.1*
-net-analyzer/smbmap
+~net-analyzer/smbmap-1.1.0-r1
+~net-analyzer/aquatone-1.7.0-r1
 
 ### Gentoo (unverified) ###
 

--- a/profiles/pentoo/base/package.accept_keywords/net-wireless
+++ b/profiles/pentoo/base/package.accept_keywords/net-wireless
@@ -108,6 +108,8 @@ net-wireless/wifite
 
 =net-wireless/proxmark3-3.1*
 
+~net-wireless/create_ap-0.4.6
+
 #below here likely needs cleanup
 net-wireless/acx
 net-wireless/acx-firmware amd64


### PR DESCRIPTION
I noticed some missing keywords for some packages I use (and probably other people as well). I usually just add those keywords to my own package.accept_keywords file but perhaps these should be added to the overlay instead, right?