### PR TITLE
sys-kernel/kconfig-hardened-check: Convert ebuild to use distutils-r1.eclass

### DIFF
--- a/sys-kernel/kconfig-hardened-check/kconfig-hardened-check-9999.ebuild
+++ b/sys-kernel/kconfig-hardened-check/kconfig-hardened-check-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{6,7,8} )
 
-inherit python-r1
+inherit distutils-r1
 
 DESCRIPTION="A script for checking the hardening options in the Linux kernel config"
 HOMEPAGE="https://github.com/a13xp0p0v/kconfig-hardened-check"
@@ -25,7 +25,6 @@ RDEPEND="${PYTHON_DEPS}"
 DEPEND="${RDEPEND}"
 
 src_install() {
-	dodoc -r config_files/ README.md
-	python_foreach_impl python_newscript \
-		kconfig-hardened-check.py kconfig-hardened-check
+	distutils-r1_src_install
+	dodoc -r "${PN//-/_}"/config_files/ README.md
 }


### PR DESCRIPTION
Upstream uses setuptools since https://github.com/a13xp0p0v/kconfig-hardened-check/commit/18c23c0e80ec6317566a282d29f8fc65ca262f54