### PR TITLE
Update powershell-bin-7.0.2.ebuild

### DIFF
--- a/dev-lang/powershell-bin/powershell-bin-7.0.2.ebuild
+++ b/dev-lang/powershell-bin/powershell-bin-7.0.2.ebuild
@@ -9,6 +9,9 @@ DESCRIPTION="A cross-platform automation and configuration tool/framework"
 HOMEPAGE="https://github.com/Powershell/Powershell"
 SRC_URI="
 	amd64? ( https://github.com/PowerShell/PowerShell/releases/download/v${PV}/powershell-${PV}-1.rhel.7.x86_64.rpm )
+	#powershell-${PV}-linux-x64.tar.gz# alt tarballoption
+	#arm? ( https://github.com/PowerShell/PowerShell/releases/download/v${PV}/powershell-${PV}-linux-arm32.tar.gz )
+	#am64? ( https://github.com/PowerShell/PowerShell/releases/download/v${PV}/powershell-${PV}-linux-arm64.tar.gz )
 "
 
 LICENSE="MIT"


### PR DESCRIPTION
adds arm/arm64 file locations to URI. 
for the moment RPI4 has mannually extracted tarball ..  @ /opt/microsoft/powershell/7/

wile their isn't exactly a profile for pentoo on arm64 , doing my best to build seeds packages by hand.  and if this upstream's eventually  to Gentoo 1 less thing.