### PR TITLE
net-analyzer/dirsearch: Fix dependency on python >= 3.7

### DIFF
--- a/net-analyzer/dirsearch/dirsearch-0.3.8-r1.ebuild
+++ b/net-analyzer/dirsearch/dirsearch-0.3.8-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{5,6,7} )
-PYTHON_REQ_USE="threads"
+PYTHON_REQ_USE="threads(+)"
 
 inherit eutils python-single-r1
 

--- a/net-analyzer/dirsearch/dirsearch-0.3.9.ebuild
+++ b/net-analyzer/dirsearch/dirsearch-0.3.9.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{5,6,7,8} )
-PYTHON_REQ_USE="threads"
+PYTHON_REQ_USE="threads(+)"
 
 inherit eutils python-single-r1
 


### PR DESCRIPTION
net-analyzer/dirsearch depends on Python with the `threads` USE flag. This flag was dropped with Python 3.7 and later. Portage therefore fails to resolve the dependency and dirsearch can not be installed for Python 3.7+.
This PR fixes the USE flag dependency so dirsearch can be installed with with modern Python versions.