### PR TITLE
powershell: Depend on libcxxabi not libunwind

### DIFF
--- a/app-shells/pwsh-bin/pwsh-bin-7.0.2-r2.ebuild
+++ b/app-shells/pwsh-bin/pwsh-bin-7.0.2-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="7"
@@ -21,7 +21,7 @@ QA_PREBUILT="*"
 DEPEND=""
 RDEPEND="${DEPEND}
 	>=sys-apps/lsb-release-1.4
-	>=sys-libs/libunwind-1.1-r1
+	sys-libs/libcxxabi[libunwind]
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
 	|| ( dev-libs/openssl-compat:1.0.0 =dev-libs/openssl-1.0*:0 )


### PR DESCRIPTION
Dependency on libcxx was added in
9b9f87122250c3a8982981afbaef8e5877ca0e5d
but was removed again with 8556fea9d4a4e23bd847145e64d87a04b9b4295c

Powershell runs fine with this change.

Ultimativelly libunwind prevents usage of net-im/discord-bin.

Fixes #618