### PR TITLE
genmenu: Remove symlink for fern-wifi-cracker

### DIFF
--- a/app-admin/genmenu/genmenu-9999.ebuild
+++ b/app-admin/genmenu/genmenu-9999.ebuild
@@ -18,10 +18,8 @@ DEPEND=">=dev-python/lxml-1.3.6"
 RDEPEND="${DEPEND}"
 
 src_install() {
-	local DEST="/usr/share/fern-wifi-cracker"
 	insinto /usr/
 	doins -r "${S}"/src/share
-	dosym "${DEST}/resources/icon.png" /usr/share/pixmaps/fern-wifi-cracker.png
 	chown -R root:root "${ED}"
 	dobin src/bin/genmenu.py src/bin/launch
 }


### PR DESCRIPTION
Both app-admin/genmenu and net-wireless/fern-wifi-cracker create the
same symlink.

If genmenu is installed without fern-wifi-cracker present,
then there is a QA Notice symlink target does not exist.
Installing fern-wifi-cracker after genmenu fails due to file collision.

app-admin/genmenu:
Symlink was added in 2015 with ae660fbbd8751e04b761036eb610dcb1edf85877

net-wireless/fern-wifi-cracker
Symlink was added in 2019 with da69abbc3e29b7a8a2a5c03de607cd5db1f06c35