### PR TITLE
Update empire-3.3.1.ebuild

### DIFF
--- a/app-exploits/empire/empire-3.3.1.ebuild
+++ b/app-exploits/empire/empire-3.3.1.ebuild
@@ -17,7 +17,7 @@ KEYWORDS="~amd64 ~x86"
 LICENSE="BSD"
 SLOT="0"
 IUSE="powershell java"
-REQUIRED_USE="powershell? ( amd64 )"
+#REQUIRED_USE="powershell? ( amd64 )"
 
 # waiting for the upstream
 # https://bugs.gentoo.org/684734
@@ -44,8 +44,7 @@ RDEPEND="${PYTHON_DEPS}
 		dev-python/bcrypt[${PYTHON_MULTI_USEDEP}]
 		dev-python/pycryptodome[${PYTHON_MULTI_USEDEP}]
 	')
-	powershell? (
-		amd64? ( app-shells/pwsh-bin ) )
+	powershell? ( ( app-shells/pwsh-bin ) )
 	java? (
 		|| ( virtual/jre:* virtual/jdk:* ) )"
 


### PR DESCRIPTION
`# use amd64 && rm libcrypto.so.1.0.0 libssl.so.1.0.0 || die / pwsh-bin-7.0.3.ebuild`  binary pkg can be cajoled into it... some reason hates this 
a quick # out and builds.. 
and likewise can use on arm64 ,  since pwsh-bin bit messy but doable ...