### PR TITLE
Update pentoo-cinnamon-2018.2.ebuild

### DIFF
--- a/pentoo/pentoo-cinnamon/pentoo-cinnamon-2018.2.ebuild
+++ b/pentoo/pentoo-cinnamon/pentoo-cinnamon-2018.2.ebuild
@@ -18,8 +18,9 @@ PDEPEND="
 	>=x11-terms/gnome-terminal-3.4.0
 	>=media-gfx/gnome-screenshot-3.4.1
 	>=gnome-extra/gnome-system-monitor-3.4.0
-	>=gnome-extra/gnome-screensaver-3.4.0
+	>=gnome-extra/cinnamon-screensaver-4.4.1
 	>=gnome-extra/gcalctool-3.4.0
 	>=media-gfx/eog-3.4.0
 	>=app-text/evince-3.4.0
 	gdm? ( >=gnome-base/gdm-3.4.1 )"
+   


### PR DESCRIPTION
http://gpo.zugaina.org/Overlays/sping/gnome-extra/gnome-screensaver , OLD.  #>=gnome-extra/gnome-screensaver-3.4.0 no longer in Gentoo Stale version 
https://data.gpo.zugaina.org/gentoo/gnome-extra/cinnamon-screensaver/cinnamon-screensaver-4.4.1.ebuild