### PR TITLE
Update pentoo-cinnamon-2018.2.ebuild

### DIFF
--- a/pentoo/pentoo-cinnamon/pentoo-cinnamon-2018.2.ebuild
+++ b/pentoo/pentoo-cinnamon/pentoo-cinnamon-2018.2.ebuild
@@ -19,7 +19,6 @@ PDEPEND="
 	>=media-gfx/gnome-screenshot-3.4.1
 	>=gnome-extra/gnome-system-monitor-3.4.0
 	>=gnome-extra/cinnamon-screensaver-4.4.1
-	>=gnome-extra/gcalctool-3.4.0
 	>=media-gfx/eog-3.4.0
 	>=app-text/evince-3.4.0
 	gdm? ( >=gnome-base/gdm-3.4.1 )"


### PR DESCRIPTION
 Drop package due bug #508854 gcalctool-6.6.2.ebuild (dead)	 1.8	 5 years	 pacho	 Drop package due bug  )Gentoo #508854
found when force building S@#$%^ for arm64..