### PR TITLE
pentoo-updater: Remove genkernel option disklabel

### DIFF
--- a/scripts/pentoo-updater.sh
+++ b/scripts/pentoo-updater.sh
@@ -210,7 +210,7 @@ update_kernel() {
   fi
 
   #then we set genkernel options as needed
-  genkernelopts="--kernel-config=/usr/share/pentoo-sources/config-${ARCH}-${bestkern_pv} --disklabel --compress-initramfs-type=xz --bootloader=grub2 --save-config --kernel-filename=kernel-genkernel-%%ARCH%%-%%KV%% --initramfs-filename=initramfs-genkernel-%%ARCH%%-%%KV%% --systemmap-filename=System.map-genkernel-%%ARCH%%-%%KV%% --kernel-localversion=UNSET --module-rebuild --save-config --no-microcode-initramfs"
+  genkernelopts="--kernel-config=/usr/share/pentoo-sources/config-${ARCH}-${bestkern_pv} --compress-initramfs-type=xz --bootloader=grub2 --save-config --kernel-filename=kernel-genkernel-%%ARCH%%-%%KV%% --initramfs-filename=initramfs-genkernel-%%ARCH%%-%%KV%% --systemmap-filename=System.map-genkernel-%%ARCH%%-%%KV%% --kernel-localversion=UNSET --module-rebuild --save-config --no-microcode-initramfs"
   if grep -q btrfs /etc/fstab || grep -q btrfs /proc/cmdline; then
     genkernelopts="${genkernelopts} --btrfs"
   fi


### PR DESCRIPTION
Option --disklabel was removed from genkernel:
https://github.com/gentoo/genkernel/commit/945b3dc65cb2577a9962db40848eaeae3fc2a425
Genkernel-4.1.2 became stable:
https://github.com/gentoo/gentoo/commit/89de8857672c0d7efb6a630b4075b6119527b893

Fixes: #672