### PR TITLE
Removed bundle install --local from net-analyzer/wpscan

### DIFF
--- a/net-analyzer/wpscan/wpscan-3.8.7-r1.ebuild
+++ b/net-analyzer/wpscan/wpscan-3.8.7-r1.ebuild
@@ -27,6 +27,5 @@ each_ruby_prepare() {
 #	sed -i "s|'activesupport', '~> 5.1'|'activesupport'|g" wpscan.gemspec
 #	sed -i -e '/activesupport/,/^-/ s:^:#:' ../metadata || die
 	sed -i -e '/s.add_development_dependency/d' wpscan.gemspec
-	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle install --local || die
 	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle check || die
 }

--- a/net-analyzer/wpscan/wpscan-3.8.8.ebuild
+++ b/net-analyzer/wpscan/wpscan-3.8.8.ebuild
@@ -27,6 +27,5 @@ each_ruby_prepare() {
 #	sed -i "s|'activesupport', '~> 5.1'|'activesupport'|g" wpscan.gemspec
 #	sed -i -e '/activesupport/,/^-/ s:^:#:' ../metadata || die
 	sed -i -e '/s.add_development_dependency/d' wpscan.gemspec
-	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle install --local || die
 	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle check || die
 }

--- a/net-analyzer/wpscan/wpscan-3.8.9.ebuild
+++ b/net-analyzer/wpscan/wpscan-3.8.9.ebuild
@@ -27,6 +27,5 @@ each_ruby_prepare() {
 #	sed -i "s|'activesupport', '~> 5.1'|'activesupport'|g" wpscan.gemspec
 #	sed -i -e '/activesupport/,/^-/ s:^:#:' ../metadata || die
 	sed -i -e '/s.add_development_dependency/d' wpscan.gemspec
-	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle install --local || die
 	BUNDLE_GEMFILE=Gemfile ${RUBY} -S bundle check || die
 }


### PR DESCRIPTION
Bundle check appears to be enough.
Fixes sandbox violation with >=dev-ruby/bundler-2.0.0
See: https://bugs.gentoo.org/688310#c10