### PR TITLE
sys-devel/gef: Remove Dockerfile from installed docs

### DIFF
--- a/sys-devel/gef/gef-9999.ebuild
+++ b/sys-devel/gef/gef-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -66,7 +66,7 @@ src_install() {
 		dodoc -r html/
 	fi
 
-	dodoc README.md Dockerfile
+	dodoc README.md
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Since v2021.01 GEF doesn't ship with a Dockerfile.

Package-Manager: Portage-3.0.18, Repoman-3.0.3
Signed-off-by: Azat Bahawi <azahi@teknik.io>