### PR TITLE
Bump two packages for the python 3.9 switch

### DIFF
--- a/app-exploits/ropper/ropper-9999.ebuild
+++ b/app-exploits/ropper/ropper-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 DISTUTILS_USE_SETUPTOOLS=rdepend
-PYTHON_COMPAT=( python3_{6,7,8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit distutils-r1
 

--- a/sys-devel/gef/gef-9999.ebuild
+++ b/sys-devel/gef/gef-9999.ebuild
@@ -3,8 +3,7 @@
 
 EAPI=7
 
-#dev-libs/keystone does not support python3.9 yet
-PYTHON_COMPAT=( python3_{7..8} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit eutils python-single-r1
 


### PR DESCRIPTION
Gentoo recently switched to using python 3.9 as the default, and these two packages were left behind on my system. I am sure there are others that need to be bumped, but this is what affected me.

This makes changes to `*-9999.ebuild` packages, which are symlinked to by actual versioned packages. I don't know what the policy is there but those packages may need to be incremented to have an `-r1` suffix.