### PR TITLE
unicorn: fix files missing from install

### DIFF
--- a/dev-util/unicorn/unicorn-1.0.3-r1.ebuild
+++ b/dev-util/unicorn/unicorn-1.0.3-r1.ebuild
@@ -82,7 +82,7 @@ src_install() {
 		UNICORN_ARCHS="${unicorn_targets}" \
 		DESTDIR="${D}" \
 		LIBDIR="/usr/$(get_libdir)" \
-		UNICORN_STATIC="$(use static-libs && echo yes || echo no)"
+		UNICORN_STATIC="$(use static-libs && echo yes || echo no)" \
 		install
 	wrap_python ${FUNCNAME}
 }


### PR DESCRIPTION
unicorn-1.0.3 wasn't installing any of the headers or libraries. In fact, when the python USE flag was omitted, it wasn't installing any files at all.

The problem was a minor typo, which is fixed now.