### PR TITLE
pwndbg: 20210622 ebuild

### DIFF
--- a/sys-devel/pwndbg/pwndbg-20210622.ebuild
+++ b/sys-devel/pwndbg/pwndbg-20210622.ebuild
@@ -1,0 +1,1 @@
+pwndbg-99999999.ebuild


### PR DESCRIPTION
https://github.com/pwndbg/pwndbg/releases/tag/2021.06.22

Seems to work. I didn't take the time to try and fix the missing `doc` and `test` USE flags, as indicated in the comments.