### PR TITLE
pwntools: set unicorn dependency to proper version

### DIFF
--- a/app-exploits/pwntools/pwntools-4.5.1-r1.ebuild
+++ b/app-exploits/pwntools/pwntools-4.5.1-r1.ebuild
@@ -1,0 +1,45 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{7..9} )
+DISTUTILS_USE_SETUPTOOLS=rdepend
+inherit distutils-r1
+
+DESCRIPTION="CTF framework and exploit development library"
+HOMEPAGE="https://github.com/Gallopsled/pwntools"
+SRC_URI="https://github.com/Gallopsled/pwntools/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+#Most is under an MIT license, but a few pieces are under GPL or a BSD 2-clause licence
+LICENSE="MIT"
+SLOT="0"
+#wait for capstone (ROPgadget dep) to become stable
+KEYWORDS="~amd64 ~x86"
+
+RDEPEND="${PYTHON_DEPS}
+	>=dev-python/paramiko-1.15.2[${PYTHON_USEDEP}]
+	>=dev-python/mako-1.0.0[${PYTHON_USEDEP}]
+	>=dev-python/pyelftools-0.2.4[${PYTHON_USEDEP}]
+	>=dev-libs/capstone-3.0.5[python,${PYTHON_USEDEP}]
+	>=app-exploits/ropgadget-5.3[${PYTHON_USEDEP}]
+	>=dev-python/pyserial-2.7[${PYTHON_USEDEP}]
+	>=dev-python/requests-2.0[${PYTHON_USEDEP}]
+	>=dev-python/pygments-2.0[${PYTHON_USEDEP}]
+	dev-python/PySocks[${PYTHON_USEDEP}]
+	dev-python/python-dateutil[${PYTHON_USEDEP}]
+	dev-python/packaging[${PYTHON_USEDEP}]
+	>=dev-python/psutil-3.3.0[${PYTHON_USEDEP}]
+	>=dev-python/intervaltree-3.0[${PYTHON_USEDEP}]
+	dev-python/sortedcontainers[${PYTHON_USEDEP}]
+	<dev-util/unicorn-1.0.2_rc4[python,unicorn_targets_x86(+),${PYTHON_USEDEP}]
+	>=dev-python/six-1.12.0[${PYTHON_USEDEP}]
+	dev-python/rpyc[${PYTHON_USEDEP}]
+	dev-python/colored-traceback[${PYTHON_USEDEP}]
+	"
+DEPEND="${RDEPEND}"
+
+PATCHES=(
+	"${FILESDIR}/${PN}-4.0.0_do_not_mess_with_docs.patch"
+	"${FILESDIR}/${PN}-4.1.0_update_deps.patch"
+)


### PR DESCRIPTION
The current version of pwntools depends on a specific version of unicorn (see https://github.com/Gallopsled/pwntools/blob/5b0bec0c09c24f769a02b676500795db36dd40e0/setup.py#L63). It seems to work fine with the more recent unicorn, but according to issues on the pwntools and unicorn github (see the above link if interested), there is a bug related to MIPS support. So this just mimics pwntool's native `setup.py` by requiring a specific version of unicorn, which we already have in the pentoo tree anyway.

As with these diffs that involve new copies of files, it's hard to see a diff, but all I did was change line 35 to depend on that specific unicorn version, rather than pulling in just any version.