### PR TITLE
sdrangel: fix DSD plugin

### DIFF
--- a/net-wireless/sdrangel/sdrangel-6.15.1.ebuild
+++ b/net-wireless/sdrangel/sdrangel-6.15.1.ebuild
@@ -70,6 +70,7 @@ src_prepare() {
 
 src_configure() {
 	mycmakeargs=(
+		-DDSDCC_DIR="/usr/include/dsdcc" \
 		-DDEBUG_OUTPUT="$(usex debug)" \
 		-DSANITIZE_ADDRESS=OFF \
 		-DRX_SAMPLE_24BIT=ON \


### PR DESCRIPTION
Package was building with all required dependencies but DSD plugin was not enabled at compile time this should fix it