### PR TITLE
dev-libs/nanopb: Provides pb_release symbole

### DIFF
--- a/dev-libs/nanopb/metadata.xml
+++ b/dev-libs/nanopb/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<use>
+		<flag name="pb-malloc">Enable dynamic allocation support in the decoder.</flag>
+	</use>
+</pkgmetadata>

--- a/dev-libs/nanopb/nanopb-0.4.6-r1.ebuild
+++ b/dev-libs/nanopb/nanopb-0.4.6-r1.ebuild
@@ -3,16 +3,16 @@
 
 EAPI=8
 
-inherit cmake
+inherit cmake flag-o-matic
 
 DESCRIPTION="plain-C Protocol Buffers for embedded/memory-constrained systems"
-HOMEPAGE="http://koti.kapsi.fi/jpa/nanopb/"
-SRC_URI="http://koti.kapsi.fi/~jpa/nanopb/download/${P}.tar.gz"
+HOMEPAGE="https://jpa.kapsi.fi/nanopb/ https://github.com/nanopb/nanopb"
+SRC_URI="https://github.com/nanopb/${PN}/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="ZLIB"
 SLOT="0"
 KEYWORDS="amd64 ~arm64 x86"
-IUSE="doc examples"
+IUSE="doc examples pb-malloc"
 
 RDEPEND="
 	dev-libs/protobuf
@@ -23,6 +23,11 @@ DEPEND="
 "
 
 S="${WORKDIR}/${PN}"
+
+src_configure() {
+	use pb-malloc && append-cppflags "-DPB_ENABLE_MALLOC"
+	cmake_src_configure
+}
 
 src_test() {
 	cd "${S}"/tests


### PR DESCRIPTION
Modification required by net-wireless/qflipper

Signed-off-by: Thibaud CANALE <thican@thican.net>