### PR TITLE
dev-python/apng: Remove pathlib2 dependency

### DIFF
--- a/dev-python/apng/apng-0.3.3.ebuild
+++ b/dev-python/apng/apng-0.3.3.ebuild
@@ -17,7 +17,6 @@ KEYWORDS="~amd64 ~x86"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
-	>=dev-python/pathlib2-2.3.3[${PYTHON_USEDEP}]
 	>=dev-python/pylint-2.2.2[${PYTHON_USEDEP}]
 	dev-python/twine[${PYTHON_USEDEP}]
 	dev-python/wheel[${PYTHON_USEDEP}]"

--- a/dev-python/apng/apng-0.3.4.ebuild
+++ b/dev-python/apng/apng-0.3.4.ebuild
@@ -17,7 +17,6 @@ KEYWORDS="~amd64 ~x86"
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 DEPEND="${PYTHON_DEPS}
-	>=dev-python/pathlib2-2.3.3[${PYTHON_USEDEP}]
 	>=dev-python/pylint-2.2.2[${PYTHON_USEDEP}]
 	dev-python/twine[${PYTHON_USEDEP}]
 	dev-python/wheel[${PYTHON_USEDEP}]"


### PR DESCRIPTION
Not only is the backported module functionality not needed upstream, but moreover it is only used in tests with are deleted right away during prepare phase.  This fixes a non-existing dependency of for pathlib2 with newer python.