### PR TITLE
dev-ruby/cms_scanner: update dependencies

### DIFF
--- a/dev-ruby/cms_scanner/cms_scanner-0.13.6.ebuild
+++ b/dev-ruby/cms_scanner/cms_scanner-0.13.6.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 USE_RUBY="ruby27 ruby30 ruby31"
 RUBY_FAKEGEM_EXTRAINSTALL="app"
@@ -17,10 +17,10 @@ SLOT="0"
 
 ruby_add_rdepend "
 	=dev-ruby/get_process_mem-0.2*
-	=dev-ruby/nokogiri-1.11*
+	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.13.0
 	>=dev-ruby/opt_parse_validator-1.9.5
 	>=dev-ruby/public_suffix-4.0.3:4
-	=dev-ruby/ruby-progressbar-1.10*
+	>=dev-ruby/ruby-progressbar-1.10 <dev-ruby/ruby-progressbar-1.12
 	dev-ruby/typhoeus:1
 	=dev-ruby/ethon-0.14*
 	=dev-ruby/xmlrpc-0*

--- a/dev-ruby/cms_scanner/cms_scanner-0.13.7.ebuild
+++ b/dev-ruby/cms_scanner/cms_scanner-0.13.7.ebuild
@@ -17,12 +17,12 @@ SLOT="0"
 
 ruby_add_rdepend "
 	=dev-ruby/get_process_mem-0.2*
-	>=dev-ruby/nokogiri-1.11.2 <dev-ruby/nokogiri-1.14.0
+	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.14.0
 	>=dev-ruby/opt_parse_validator-1.9.5
 	>=dev-ruby/public_suffix-4.0.3:4
-	=dev-ruby/ruby-progressbar-1.10*
+	>=dev-ruby/ruby-progressbar-1.10 <dev-ruby/ruby-progressbar-1.12
 	dev-ruby/typhoeus:1
-	=dev-ruby/ethon-0.14*
+	>=dev-ruby/ethon-0.14 <dev-ruby/ethon-0.16
 	=dev-ruby/xmlrpc-0*
 	=dev-ruby/yajl-ruby-1.4*
 

--- a/dev-ruby/cms_scanner/cms_scanner-0.13.8.ebuild
+++ b/dev-ruby/cms_scanner/cms_scanner-0.13.8.ebuild
@@ -17,12 +17,12 @@ SLOT="0"
 
 ruby_add_rdepend "
 	=dev-ruby/get_process_mem-0.2*
-	>=dev-ruby/nokogiri-1.11.2 <dev-ruby/nokogiri-1.14.0
+	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.14.0
 	>=dev-ruby/opt_parse_validator-1.9.5
 	>=dev-ruby/public_suffix-4.0.3:4
-	=dev-ruby/ruby-progressbar-1.10*
+	>=dev-ruby/ruby-progressbar-1.10 <dev-ruby/ruby-progressbar-1.12
 	dev-ruby/typhoeus:1
-	=dev-ruby/ethon-0.14*
+	>=dev-ruby/ethon-0.14 <dev-ruby/ethon-0.16
 	=dev-ruby/xmlrpc-0*
 	=dev-ruby/yajl-ruby-1.4*
 


### PR DESCRIPTION
Portage dropped the old ethon version so dependency resolution was broken. I synced this with upstream. This fixes dep resolution and might be enough to allow for building wpscan on ruby3.0/3.1 target.

Signed-off-by: Joe Kappus <joe@wt.gd>