### PR TITLE
Correct the hackrf USE flag dependency of the sdrpp pkg

### DIFF
--- a/net-wireless/sdrpp/sdrpp-1.0.4.ebuild
+++ b/net-wireless/sdrpp/sdrpp-1.0.4.ebuild
@@ -22,7 +22,7 @@ DEPEND="sci-libs/fftw
 	airspy? ( net-wireless/airspy )
 	airspyhf? ( net-wireless/airspyhf )
 	bladerf? ( net-wireless/bladerf )
-	hackrf? ( net-wireless/libhackrf )
+	hackrf? ( net-libs/libhackrf )
 	limesdr? ( net-wireless/limesuite )
 	rtlsdr? ( net-wireless/rtl-sdr )
 	soapysdr? ( net-wireless/soapysdr )

--- a/net-wireless/sdrpp/sdrpp-9999.ebuild
+++ b/net-wireless/sdrpp/sdrpp-9999.ebuild
@@ -22,7 +22,7 @@ DEPEND="sci-libs/fftw
 	airspy? ( net-wireless/airspy )
 	airspyhf? ( net-wireless/airspyhf )
 	bladerf? ( net-wireless/bladerf )
-	hackrf? ( net-wireless/libhackrf )
+	hackrf? ( net-libs/libhackrf )
 	limesdr? ( net-wireless/limesuite )
 	rtlsdr? ( net-wireless/rtl-sdr )
 	soapysdr? ( net-wireless/soapysdr )


### PR DESCRIPTION
Hi,  we are having a compile problem when emerging sdrpp , with USE flag hackrf. (already reported in discord pentoo) 
The error was the following one 
![image](https://user-images.githubusercontent.com/86470699/218582203-651d74a5-51b7-41f7-9752-8289b1d93ea1.png)


Comparing the other sdrpp  ebuilds from Hamari overlays  to our pentoo overlays , I could find the problem in the ebuild link, 
I could not test the c/m ,  but I belived that this PR will solve both versions,  1.0.4, and -9999.
https://gpo.zugaina.org/net-wireless/sdrpp
![image](https://user-images.githubusercontent.com/86470699/218582675-21cc0ebf-0acb-455b-bb2a-bfb2f6fb05f2.png)


Cheers, 