### PR TITLE
dev-ruby/cms_scanner: fix nokogiri dep

### DIFF
--- a/dev-ruby/cms_scanner/cms_scanner-0.13.8.ebuild
+++ b/dev-ruby/cms_scanner/cms_scanner-0.13.8.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 
 ruby_add_rdepend "
 	=dev-ruby/get_process_mem-0.2*
-	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.15.0
+	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.14.0
 	>=dev-ruby/opt_parse_validator-1.9.5
 	>=dev-ruby/public_suffix-4.0.3:4
 	>=dev-ruby/ruby-progressbar-1.10 <dev-ruby/ruby-progressbar-1.12


### PR DESCRIPTION
Build will fail with newer unless patched.

Reference: https://github.com/wpscanteam/CMSScanner/blob/v0.13.8/cms_scanner.gemspec