### PR TITLE
Remove usage of eutils.eclass

### DIFF
--- a/app-admin/vuls/vuls-0.19.0-r1.ebuild
+++ b/app-admin/vuls/vuls-0.19.0-r1.ebuild
@@ -158,7 +158,7 @@ EGO_VENDOR=(
 	"k8s.io/utils fddb29f9d009 github.com/kubernetes/utils"
 )
 
-inherit eutils golang-vcs-snapshot systemd
+inherit golang-vcs-snapshot systemd
 
 DESCRIPTION="Vulnerability scanner for Linux, agentless, written in Golang"
 HOMEPAGE="https://vuls.io https://github.com/future-architect/vuls"

--- a/app-crypt/SIPcrack/SIPcrack-0.4-r1.ebuild
+++ b/app-crypt/SIPcrack/SIPcrack-0.4-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit toolchain-funcs eutils
+inherit toolchain-funcs
 
 DESCRIPTION="SIPcrack is a SIP protocol login cracker"
 HOMEPAGE="http://www.remote-exploit.org/?page_id=418"

--- a/app-crypt/bruteforce-luks/bruteforce-luks-9999.ebuild
+++ b/app-crypt/bruteforce-luks/bruteforce-luks-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="A bruteforce cracker for LUKS encrypted volumes"
 HOMEPAGE="https://github.com/glv2/bruteforce-luks"

--- a/app-crypt/rcracki_mt/rcracki_mt-0.7.0-r1.ebuild
+++ b/app-crypt/rcracki_mt/rcracki_mt-0.7.0-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools desktop eutils multilib toolchain-funcs xdg-utils
+inherit autotools desktop multilib toolchain-funcs xdg-utils
 
 DESCRIPTION="Perform a rainbow table attack on password hashes"
 HOMEPAGE="https://freerainbowtables.com/"

--- a/app-exploits/exploit-pattern/exploit-pattern-20200109.ebuild
+++ b/app-exploits/exploit-pattern/exploit-pattern-20200109.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit python-single-r1
 
 DESCRIPTION="Generate and search pattern string for exploit development"
 HOMEPAGE="https://github.com/Svenito/exploit-pattern"

--- a/app-exploits/proton/proton-20200311.ebuild
+++ b/app-exploits/proton/proton-20200311.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 
 #inherit python-single-r1
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Windows post-exploitation framework using Windows Script Host"
 HOMEPAGE="https://github.com/entynetproject/proton"

--- a/app-exploits/weevely/weevely-9999.ebuild
+++ b/app-exploits/weevely/weevely-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Weevely is a stealth PHP web shell that simulate telnet-like console"
 HOMEPAGE="https://github.com/epinna/weevely3"

--- a/app-exploits/wesng/wesng-20200616.ebuild
+++ b/app-exploits/wesng/wesng-20200616.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Windows Exploit Suggester - Next Generation"
 HOMEPAGE="https://github.com/bitsadmin/wesng"

--- a/app-exploits/wesng/wesng-99999999.ebuild
+++ b/app-exploits/wesng/wesng-99999999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Windows Exploit Suggester - Next Generation"
 HOMEPAGE="https://github.com/bitsadmin/wesng"

--- a/app-forensics/bulk_extractor/bulk_extractor-2.0.3-r1.ebuild
+++ b/app-forensics/bulk_extractor/bulk_extractor-2.0.3-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit autotools desktop eutils xdg-utils
+inherit autotools desktop wrapper xdg-utils
 
 DESCRIPTION="Scans a disk image for regular expressions and other content"
 HOMEPAGE="https://github.com/simsong/bulk_extractor"

--- a/app-forensics/eagleeye/eagleeye-9999.ebuild
+++ b/app-forensics/eagleeye/eagleeye-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find people's social media profile using reverse image search"
 HOMEPAGE="https://github.com/ThoughtfulDev/EagleEye"

--- a/app-forensics/fuxploider/fuxploider-1.0-r1.ebuild
+++ b/app-forensics/fuxploider/fuxploider-1.0-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="File upload vulnerability scanner and exploitation tool"
 HOMEPAGE="https://github.com/almandin/fuxploider"

--- a/app-forensics/fuxploider/fuxploider-9999.ebuild
+++ b/app-forensics/fuxploider/fuxploider-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="File upload vulnerability scanner and exploitation tool"
 HOMEPAGE="https://github.com/almandin/fuxploider"

--- a/app-forensics/maltego/maltego-4.2.18.13878.ebuild
+++ b/app-forensics/maltego/maltego-4.2.18.13878.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit desktop eutils unpacker xdg-utils
+inherit desktop wrapper unpacker xdg-utils
 
 DESCRIPTION="Visualise, map and mine data"
 HOMEPAGE="https://www.paterva.com/"

--- a/app-forensics/spiderfoot/spiderfoot-3.0-r1.ebuild
+++ b/app-forensics/spiderfoot/spiderfoot-3.0-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="sqlite,ssl,readline"
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="The most complete OSINT collection and reconnaissance tool"
 HOMEPAGE="https://www.spiderfoot.net"

--- a/app-forensics/spiderfoot/spiderfoot-3.5-r1.ebuild
+++ b/app-forensics/spiderfoot/spiderfoot-3.5-r1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="sqlite,ssl,readline"
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="The most complete OSINT collection and reconnaissance tool"
 HOMEPAGE="https://www.spiderfoot.net"

--- a/app-forensics/xmount/xmount-0.7.6.ebuild
+++ b/app-forensics/xmount/xmount-0.7.6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils cmake
+inherit cmake
 
 DESCRIPTION="Convert on-the-fly between multiple input and output harddisk image types"
 HOMEPAGE="https://pinguin.lu/xmount"

--- a/app-fuzz/dotdotpwn/dotdotpwn-3.0.2.ebuild
+++ b/app-fuzz/dotdotpwn/dotdotpwn-3.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="The Directory Traversal Fuzzer"
 HOMEPAGE="http://dotdotpwn.blogspot.com"

--- a/app-fuzz/slowhttptest/slowhttptest-1.7_p20170811.ebuild
+++ b/app-fuzz/slowhttptest/slowhttptest-1.7_p20170811.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="Application Layer DoS attack simulator"
 HOMEPAGE="https://github.com/shekyan/slowhttptest"

--- a/app-fuzz/slowhttptest/slowhttptest-1.8.1.ebuild
+++ b/app-fuzz/slowhttptest/slowhttptest-1.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="Application Layer DoS attack simulator"
 HOMEPAGE="https://github.com/shekyan/slowhttptest"

--- a/app-fuzz/slowhttptest/slowhttptest-1.8.2.ebuild
+++ b/app-fuzz/slowhttptest/slowhttptest-1.8.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="Application Layer DoS attack simulator"
 HOMEPAGE="https://github.com/shekyan/slowhttptest"

--- a/app-misc/cyberchef/cyberchef-9.18.0.ebuild
+++ b/app-misc/cyberchef/cyberchef-9.18.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils desktop xdg-utils
+inherit wrapper desktop xdg-utils
 
 DESCRIPTION="A web app for encryption, encoding, compression and data analysis (offline)"
 HOMEPAGE="https://gchq.github.io/CyberChef"

--- a/app-misc/cyberchef/cyberchef-9.20.3.ebuild
+++ b/app-misc/cyberchef/cyberchef-9.20.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils desktop xdg-utils
+inherit wrapper desktop xdg-utils
 
 DESCRIPTION="A web app for encryption, encoding, compression and data analysis (offline)"
 HOMEPAGE="https://gchq.github.io/CyberChef"

--- a/app-misc/cyberchef/cyberchef-9.21.0.ebuild
+++ b/app-misc/cyberchef/cyberchef-9.21.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils desktop xdg-utils
+inherit wrapper desktop xdg-utils
 
 DESCRIPTION="A web app for encryption, encoding, compression and data analysis (offline)"
 HOMEPAGE="https://gchq.github.io/CyberChef"

--- a/app-misc/dangerzone/dangerzone-0.1.2-r1.ebuild
+++ b/app-misc/dangerzone/dangerzone-0.1.2-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils distutils-r1 xdg-utils
+inherit distutils-r1 xdg-utils
 
 DESCRIPTION="Take potentially dangerous PDFs or images and convert them to a safe PDF"
 HOMEPAGE="https://github.com/firstlookmedia/dangerzone"

--- a/app-misc/dangerzone/dangerzone-0.1.2.ebuild
+++ b/app-misc/dangerzone/dangerzone-0.1.2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils distutils-r1 xdg-utils
+inherit distutils-r1 xdg-utils
 
 DESCRIPTION="Take potentially dangerous PDFs or images and convert them to a safe PDF"
 HOMEPAGE="https://github.com/firstlookmedia/dangerzone"

--- a/dev-db/neo4j-community/neo4j-community-4.2.2.ebuild
+++ b/dev-db/neo4j-community/neo4j-community-4.2.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="High-performance, mature and robust NOSQL graph database"
 HOMEPAGE="https://neo4j.com/"

--- a/dev-db/oat/oat-1.3.1.ebuild
+++ b/dev-db/oat/oat-1.3.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit epatch
 
 DESCRIPTION="a toolkit that could be used to audit security within Oracle database servers"
 HOMEPAGE="http://www.cqure.net/wp/test/"

--- a/dev-db/oat/oat-1.3.1.ebuild
+++ b/dev-db/oat/oat-1.3.1.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=7
 
-inherit epatch
-
 DESCRIPTION="a toolkit that could be used to audit security within Oracle database servers"
 HOMEPAGE="http://www.cqure.net/wp/test/"
 SRC_URI="http://www.vulnerabilityassessment.co.uk/oat-binary-1.3.1.zip"
@@ -20,7 +18,7 @@ S="${WORKDIR}"/"${PN}"
 
 src_compile(){
 	einfo "Nothing to compile"
-	epatch "${FILESDIR}"/"${PN}"-path.patch
+	eapply "${FILESDIR}"/"${PN}"-path.patch
 }
 
 src_install() {

--- a/dev-embedded/libmpsse/libmpsse-1.3.2-r1.ebuild
+++ b/dev-embedded/libmpsse/libmpsse-1.3.2-r1.ebuild
@@ -4,9 +4,9 @@
 EAPI=7
 
 #PYTHON_COMPAT=( python2_7 )
-#inherit eutils python-single-r1 autotools
+#inherit python-single-r1 autotools
 
-inherit eutils autotools
+inherit autotools
 
 DESCRIPTION="Open source library for SPI/I2C control via FTDI chips"
 HOMEPAGE="https://github.com/l29ah/libmpsse"

--- a/dev-embedded/mphidflash/mphidflash-1.8.ebuild
+++ b/dev-embedded/mphidflash/mphidflash-1.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit epatch
 
 DESCRIPTION="Tool for communicating with the USB-Bootloader in PIC microcontrollers"
 HOMEPAGE="https://github.com/ApertureLabsLtd/mphidflash"

--- a/dev-embedded/mphidflash/mphidflash-1.8.ebuild
+++ b/dev-embedded/mphidflash/mphidflash-1.8.ebuild
@@ -3,8 +3,6 @@
 
 EAPI=7
 
-inherit epatch
-
 DESCRIPTION="Tool for communicating with the USB-Bootloader in PIC microcontrollers"
 HOMEPAGE="https://github.com/ApertureLabsLtd/mphidflash"
 #SRC_URI="http://dev.pentoo.ch/~zero/distfiles/${P}-src.tar.gz"
@@ -23,7 +21,7 @@ RDEPEND="${DEPEND}"
 S="${WORKDIR}"
 
 src_prepare() {
-	epatch "${FILESDIR}"/"${P}"-makefile.patch
+	eapply "${FILESDIR}"/"${P}"-makefile.patch
 	default
 }
 

--- a/dev-java/msgpack/msgpack-0.5.1.ebuild
+++ b/dev-java/msgpack/msgpack-0.5.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils java-pkg-2 java-pkg-simple
+inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="MessagePack for Java is a binary-based efficient object serialization library"
 HOMEPAGE="http://msgpack.org"

--- a/dev-java/msgpack/msgpack-0.6.12.ebuild
+++ b/dev-java/msgpack/msgpack-0.6.12.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils java-pkg-2 java-pkg-simple
+inherit java-pkg-2 java-pkg-simple
 
 DESCRIPTION="MessagePack for Java is a binary-based efficient object serialization library"
 HOMEPAGE="http://msgpack.org"

--- a/dev-java/sleep/sleep-2.1-r1.ebuild
+++ b/dev-java/sleep/sleep-2.1-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils java-pkg-2 java-ant-2
+inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Duct Tape for the Java platform"
 HOMEPAGE="http://sleep.dashnine.org/"

--- a/dev-libs/libguytools2/libguytools2-2.1.0.ebuild
+++ b/dev-libs/libguytools2/libguytools2-2.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils qmake-utils
+inherit qmake-utils
 
 DESCRIPTION="Library for guymager"
 HOMEPAGE="http://libguytools.sourceforge.net/"

--- a/dev-libs/qbdi/qbdi-0.7.1.ebuild
+++ b/dev-libs/qbdi/qbdi-0.7.1.ebuild
@@ -14,7 +14,7 @@ LLVM_P="llvm-${LLVM_PV}.src"
 LLVM_TARGET="X86" # FIXME: only amd64 and x86 support in the current moment
 LLVM_S="${WORKDIR}/${LLVM_P}"
 
-inherit cmake eutils python-single-r1
+inherit cmake toolchain-funcs wrapper python-single-r1
 
 DESCRIPTION="A Dynamic Binary Instrumentation framework based on LLVM"
 HOMEPAGE="https://qbdi.quarkslab.com/"

--- a/dev-util/sonarscanner-bin/sonarscanner-bin-4.3.0.2102.ebuild
+++ b/dev-util/sonarscanner-bin/sonarscanner-bin-4.3.0.2102.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="SonarQube Command-Line Scanner"
 HOMEPAGE="https://www.sonarqube.org/"

--- a/dev-util/sonarscanner-bin/sonarscanner-bin-4.4.0.2170.ebuild
+++ b/dev-util/sonarscanner-bin/sonarscanner-bin-4.4.0.2170.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="SonarQube Command-Line Scanner"
 HOMEPAGE="https://www.sonarqube.org/"

--- a/dev-vcs/gitleaks/gitleaks-4.3.1.ebuild
+++ b/dev-vcs/gitleaks/gitleaks-4.3.1.ebuild
@@ -54,7 +54,7 @@ EGO_VENDOR=(
 	"gopkg.in/yaml.v2 v2.2.4 github.com/go-yaml/yaml"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Audit git repos for secrets"
 HOMEPAGE="https://github.com/zricethezav/gitleaks"

--- a/dev-vcs/gitleaks/gitleaks-6.1.2.ebuild
+++ b/dev-vcs/gitleaks/gitleaks-6.1.2.ebuild
@@ -55,7 +55,7 @@ EGO_VENDOR=(
 	"gopkg.in/yaml.v2 v2.2.4 github.com/go-yaml/yaml"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Audit git repos for secrets"
 HOMEPAGE="https://github.com/zricethezav/gitleaks"

--- a/net-analyzer/aquatone/aquatone-1.7.0-r2.ebuild
+++ b/net-analyzer/aquatone/aquatone-1.7.0-r2.ebuild
@@ -52,7 +52,7 @@ EGO_VENDOR=(
 	"gopkg.in/mattn/go-runewidth.v0 v0.0.4 github.com/mattn/go-runewidth"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="A Tool for Domain Flyovers"
 HOMEPAGE="https://github.com/michenriksen/aquatone https://michenriksen.com/blog/aquatone-now-in-go/"

--- a/net-analyzer/armitage-bin/armitage-bin-20140818.ebuild
+++ b/net-analyzer/armitage-bin/armitage-bin-20140818.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils multilib
+inherit desktop multilib
 
 #Crazy name, issue https://code.google.com/p/armitage/issues/detail?id=165
 MY_PV="140818"

--- a/net-analyzer/armitage-bin/armitage-bin-20141120.ebuild
+++ b/net-analyzer/armitage-bin/armitage-bin-20141120.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils multilib
+inherit desktop multilib
 
 #Crazy name, issue https://code.google.com/p/armitage/issues/detail?id=165
 MY_PV="141120"

--- a/net-analyzer/armitage-bin/armitage-bin-20150813.ebuild
+++ b/net-analyzer/armitage-bin/armitage-bin-20150813.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils multilib
+inherit desktop multilib
 
 #Crazy name, issue https://code.google.com/p/armitage/issues/detail?id=165
 MY_PV="150813"

--- a/net-analyzer/armitage/armitage-20160709-r1.ebuild
+++ b/net-analyzer/armitage/armitage-20160709-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils java-pkg-2 java-ant-2
+inherit desktop java-pkg-2 java-ant-2
 
 DESCRIPTION="Cyber Attack Management for Metasploit"
 HOMEPAGE="http://www.fastandeasyhacking.com/"

--- a/net-analyzer/armitage/armitage-9999.ebuild
+++ b/net-analyzer/armitage/armitage-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils subversion java-pkg-2 java-ant-2
+inherit desktop subversion java-pkg-2 java-ant-2
 
 DESCRIPTION="Cyber Attack Management for Metasploit"
 HOMEPAGE="http://www.fastandeasyhacking.com/"

--- a/net-analyzer/bbrecon/bbrecon-20200228.ebuild
+++ b/net-analyzer/bbrecon/bbrecon-20200228.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 DESCRIPTION="Automated reconnaissance and information gathering (fork)"
 HOMEPAGE="https://gitlab.com/0bs1d1an/bbrecon"

--- a/net-analyzer/bolt/bolt-9999.ebuild
+++ b/net-analyzer/bolt/bolt-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="CSRF Scanner"
 HOMEPAGE="https://github.com/s0md3v/Bolt"

--- a/net-analyzer/capanalysis/capanalysis-1.2.3.ebuild
+++ b/net-analyzer/capanalysis/capanalysis-1.2.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils gnome2-utils toolchain-funcs xdg-utils
+inherit desktop gnome2-utils toolchain-funcs xdg-utils
 
 DESCRIPTION="A web visual tool for information security specialists"
 HOMEPAGE="https://www.capanalysis.net https://github.com/xplico/CapAnalysis"

--- a/net-analyzer/dirble-bin/dirble-bin-1.3.1.ebuild
+++ b/net-analyzer/dirble-bin/dirble-bin-1.3.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit wrapper
 
 DESCRIPTION="Fast directory scanning and scraping tool"
 HOMEPAGE="https://github.com/nccgroup/dirble"

--- a/net-analyzer/dirble-bin/dirble-bin-1.4.2.ebuild
+++ b/net-analyzer/dirble-bin/dirble-bin-1.4.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit wrapper
 
 DESCRIPTION="Fast directory scanning and scraping tool"
 HOMEPAGE="https://github.com/nccgroup/dirble"

--- a/net-analyzer/dirsearch/dirsearch-0.3.9.ebuild
+++ b/net-analyzer/dirsearch/dirsearch-0.3.9.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="threads(+)"
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="A simple command line tool designed to brute force dirs and files in websites"
 HOMEPAGE="https://github.com/maurosoria/dirsearch"

--- a/net-analyzer/dirsearch/dirsearch-0.4.0_p20201202.ebuild
+++ b/net-analyzer/dirsearch/dirsearch-0.4.0_p20201202.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="threads(+)"
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 HASH_COMMIT="07726bbf4c5c540b0e1d974c77864a78ed21c386"
 DESCRIPTION="A simple command line tool designed to brute force dirs and files in websites"

--- a/net-analyzer/gitgraber/gitgraber-20191002.ebuild
+++ b/net-analyzer/gitgraber/gitgraber-20191002.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Tool to scan for sensitive information within public GitHub repositories"
 HOMEPAGE="https://github.com/hisxo/gitGraber"

--- a/net-analyzer/gitrob/gitrob-2.0.0_beta-r1.ebuild
+++ b/net-analyzer/gitrob/gitrob-2.0.0_beta-r1.ebuild
@@ -32,7 +32,7 @@ EGO_VENDOR=(
 	"gopkg.in/warnings.v0 v0.1.2 github.com/go-warnings/warnings"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Reconnaissance tool for GitHub organizations"
 HOMEPAGE="https://github.com/michenriksen/gitrob https://michenriksen.com/blog/gitrob-now-in-go/"

--- a/net-analyzer/go-webanalyze/go-webanalyze-20190705.ebuild
+++ b/net-analyzer/go-webanalyze/go-webanalyze-20190705.ebuild
@@ -12,7 +12,7 @@ EGO_VENDOR=(
 	"golang.org/x/text v0.3.2 github.com/golang/text"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Port of Wappalyzer in Go to automate scanning"
 HOMEPAGE="https://github.com/rverton/webanalyze"

--- a/net-analyzer/iposint/iposint-20190615-r1.ebuild
+++ b/net-analyzer/iposint/iposint-20190615-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Discovery IP Address of the target"
 HOMEPAGE="https://github.com/j3ssie/IPOsint"

--- a/net-analyzer/mosref/mosref-2.0_beta3.ebuild
+++ b/net-analyzer/mosref/mosref-2.0_beta3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+
 
 MY_P="${P/_/-}"
 DESCRIPTION="A secure remote execution framework using a compact Scheme-influenced VM"

--- a/net-analyzer/nbtool/nbtool-20140416.ebuild
+++ b/net-analyzer/nbtool/nbtool-20140416.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils toolchain-funcs
+inherit toolchain-funcs
 
 DESCRIPTION="Some tools for NetBIOS and DNS investigation, attacks, and communication"
 HOMEPAGE="https://www.skullsecurity.org/wiki/index.php/Nbtool"

--- a/net-analyzer/osmedeus/osmedeus-9999.ebuild
+++ b/net-analyzer/osmedeus/osmedeus-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils git-r3 python-r1
+inherit wrapper git-r3 python-r1
 
 DESCRIPTION="A offensive security tool for reconnaissance and vulnerability scanning"
 HOMEPAGE="https://github.com/j3ssie/Osmedeus"

--- a/net-analyzer/s3scanner/s3scanner-1.0.0_p20190928.ebuild
+++ b/net-analyzer/s3scanner/s3scanner-1.0.0_p20190928.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Scan for open AWS S3 buckets and dump the contents"
 HOMEPAGE="https://github.com/sa7mon/S3Scanner"

--- a/net-analyzer/s3scanner/s3scanner-2.0.1.ebuild
+++ b/net-analyzer/s3scanner/s3scanner-2.0.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Scan for open AWS S3 buckets and dump the contents"
 HOMEPAGE="https://github.com/sa7mon/S3Scanner"

--- a/net-analyzer/set/set-8.0.3-r1.ebuild
+++ b/net-analyzer/set/set-8.0.3-r1.ebuild
@@ -8,7 +8,7 @@ MY_P=${P/set/social-engineer-toolkit}
 DISTUTILS_USE_SETUPTOOLS=no
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1 multilib
+inherit epatch python-single-r1 multilib
 
 #https://github.com/trustedsec/social-engineer-toolkit/issues/622
 #inherit distutils-r1

--- a/net-analyzer/set/set-8.0.3-r1.ebuild
+++ b/net-analyzer/set/set-8.0.3-r1.ebuild
@@ -8,7 +8,7 @@ MY_P=${P/set/social-engineer-toolkit}
 DISTUTILS_USE_SETUPTOOLS=no
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit epatch python-single-r1 multilib
+inherit python-single-r1 multilib
 
 #https://github.com/trustedsec/social-engineer-toolkit/issues/622
 #inherit distutils-r1
@@ -50,7 +50,7 @@ src_prepare() {
 
 	if has_version mail-mta/ssmtp
 	then
-		epatch "${FILESDIR}"/${P}-ssmtp.patch
+		eapply "${FILESDIR}"/${P}-ssmtp.patch
 	fi
 	if has_version mail-mta/postfix
 	then

--- a/net-analyzer/subjack/subjack-2.1.ebuild
+++ b/net-analyzer/subjack/subjack-2.1.ebuild
@@ -21,7 +21,7 @@ EGO_VENDOR=(
 	"golang.org/x/text v0.3.2 github.com/golang/text"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Subdomain Takeover tool written in Go"
 HOMEPAGE="https://github.com/haccer/subjack"

--- a/net-analyzer/sublert/sublert-1.4.7_p20200103.ebuild
+++ b/net-analyzer/sublert/sublert-1.4.7_p20200103.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Monitor new subdomains deployed by specific organizations and issued TLS/SSL certificate"
 HOMEPAGE="https://github.com/yassineaboukir/sublert"

--- a/net-analyzer/voiphopper/voiphopper-2.04-r3.ebuild
+++ b/net-analyzer/voiphopper/voiphopper-2.04-r3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit linux-info eutils flag-o-matic
+inherit linux-info flag-o-matic
 
 DESCRIPTION="VoIP Hopper is a tool that rapidly runs a VLAN Hop into the Voice VLAN"
 HOMEPAGE="http://voiphopper.sourceforge.net/"

--- a/net-analyzer/xsstrike/xsstrike-3.1.5.ebuild
+++ b/net-analyzer/xsstrike/xsstrike-3.1.5.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Advanced XSS detection suite"
 HOMEPAGE="https://github.com/s0md3v/XSStrike"

--- a/net-analyzer/xsstrike/xsstrike-9999.ebuild
+++ b/net-analyzer/xsstrike/xsstrike-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Advanced XSS detection suite"
 HOMEPAGE="https://github.com/s0md3v/XSStrike"

--- a/net-mail/davmail-bin/davmail-bin-6.0.0.3375.ebuild
+++ b/net-mail/davmail-bin/davmail-bin-6.0.0.3375.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils java-pkg-2 desktop systemd
+inherit java-pkg-2 desktop systemd
 
 #https://sourceforge.net/projects/davmail/files/davmail/
 MY_PN="davmail"

--- a/net-mail/davmail-bin/davmail-bin-6.0.1.3390.ebuild
+++ b/net-mail/davmail-bin/davmail-bin-6.0.1.3390.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-inherit eutils java-pkg-2 desktop systemd
+inherit java-pkg-2 desktop systemd
 
 #https://sourceforge.net/projects/davmail/files/davmail/
 MY_PN="davmail"

--- a/net-misc/brutespray/brutespray-1.6.6.ebuild
+++ b/net-misc/brutespray/brutespray-1.6.6.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Brute-Forcing from Nmap output using default creds"
 HOMEPAGE="https://github.com/x90skysn3k/brutespray"

--- a/net-misc/brutespray/brutespray-1.6.8.ebuild
+++ b/net-misc/brutespray/brutespray-1.6.8.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Brute-Forcing from Nmap output using default creds"
 HOMEPAGE="https://github.com/x90skysn3k/brutespray"

--- a/net-misc/corscanner/corscanner-20190721.ebuild
+++ b/net-misc/corscanner/corscanner-20190721.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Fast CORS misconfiguration vulnerabilities scannerbeers"
 HOMEPAGE="https://github.com/chenjj/CORScanner"

--- a/net-misc/corscanner/corscanner-99999999.ebuild
+++ b/net-misc/corscanner/corscanner-99999999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Fast CORS misconfiguration vulnerabilities scannerbeers"
 HOMEPAGE="https://github.com/chenjj/CORScanner"

--- a/net-misc/dirscraper/dirscraper-99999999.ebuild
+++ b/net-misc/dirscraper/dirscraper-99999999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
-inherit eutils python-r1
+inherit wrapper python-r1
 
 DESCRIPTION="Scanning tool which discovers dirs found in javascript files hosted on a website"
 HOMEPAGE="https://github.com/Cillian-Collins/dirscraper"

--- a/net-misc/goaltdns/goaltdns-20190330.ebuild
+++ b/net-misc/goaltdns/goaltdns-20190330.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 EGO_PN="github.com/subfinder/goaltdns"
 EGO_VENDOR=( "github.com/bobesa/go-domain-util 1d708c0" )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="A permutation generation tool written in golang"
 HOMEPAGE="https://github.com/subfinder/goaltdns"

--- a/net-misc/gowitness/gowitness-2.3.6.ebuild
+++ b/net-misc/gowitness/gowitness-2.3.6.ebuild
@@ -41,7 +41,7 @@ EGO_VENDOR=(
 	"gorm.io/gorm v1.20.12 github.com/go-gorm/gorm"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="A web screenshot utility using Chrome Headless"
 HOMEPAGE="https://github.com/sensepost/gowitness"

--- a/net-misc/httprobe/httprobe-0.1.1.ebuild
+++ b/net-misc/httprobe/httprobe-0.1.1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 EGO_PN="github.com/tomnomnom/httprobe"
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Take a list of domains and probe for working HTTP and HTTPS servers"
 HOMEPAGE="https://github.com/tomnomnom/httprobe"

--- a/net-misc/httprobe/httprobe-0.1.2.ebuild
+++ b/net-misc/httprobe/httprobe-0.1.2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 EGO_PN="github.com/tomnomnom/httprobe"
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Take a list of domains and probe for working HTTP and HTTPS servers"
 HOMEPAGE="https://github.com/tomnomnom/httprobe"

--- a/net-misc/meg/meg-0.2.4.ebuild
+++ b/net-misc/meg/meg-0.2.4.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 EGO_PN="github.com/tomnomnom/meg"
 EGO_VENDOR=( "github.com/tomnomnom/rawhttp f7ac0ba" )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Fetch many paths for many hosts - without killing the hosts"
 HOMEPAGE="https://github.com/tomnomnom/meg"

--- a/net-misc/munin/munin-0.14.1-r2.ebuild
+++ b/net-misc/munin/munin-0.14.1-r2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Online hash checker for Virustotal and other services"
 HOMEPAGE="https://github.com/Neo23x0/munin"

--- a/net-misc/munin/munin-0.20.0.ebuild
+++ b/net-misc/munin/munin-0.20.0.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Online hash checker for Virustotal and other services"
 HOMEPAGE="https://github.com/Neo23x0/munin"

--- a/net-misc/photon/photon-9999.ebuild
+++ b/net-misc/photon/photon-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
-inherit eutils python-r1
+inherit wrapper python-r1
 
 DESCRIPTION="Incredibly fast crawler designed for OSINT"
 HOMEPAGE="https://github.com/s0md3v/Photon"

--- a/net-misc/sherlock/sherlock-0.10.4-r1.ebuild
+++ b/net-misc/sherlock/sherlock-0.10.4-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/sherlock/sherlock-0.10.5-r1.ebuild
+++ b/net-misc/sherlock/sherlock-0.10.5-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/sherlock/sherlock-0.10.9-r1.ebuild
+++ b/net-misc/sherlock/sherlock-0.10.9-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/sherlock/sherlock-0.11.1-r1.ebuild
+++ b/net-misc/sherlock/sherlock-0.11.1-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/sherlock/sherlock-0.12.9-r1.ebuild
+++ b/net-misc/sherlock/sherlock-0.12.9-r1.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/sherlock/sherlock-9999.ebuild
+++ b/net-misc/sherlock/sherlock-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Find usernames across social networks"
 HOMEPAGE="https://github.com/sherlock-project/sherlock"

--- a/net-misc/tko-subs/tko-subs-20190624.ebuild
+++ b/net-misc/tko-subs/tko-subs-20190624.ebuild
@@ -17,7 +17,7 @@ EGO_VENDOR=(
 	"golang.org/x/oauth2 0f29369 github.com/golang/oauth2"
 )
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="A tool that can help detect and takeover subdomains with dead DNS records"
 HOMEPAGE="https://github.com/anshumanbh/tko-subs"

--- a/net-misc/waybackurls/waybackurls-0.0.2.ebuild
+++ b/net-misc/waybackurls/waybackurls-0.0.2.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 EGO_PN="github.com/tomnomnom/waybackurls"
 
-inherit eutils golang-vcs-snapshot
+inherit golang-vcs-snapshot
 
 DESCRIPTION="Fetch all the URLs that the Wayback Machine knows about for a domain"
 HOMEPAGE="https://github.com/tomnomnom/waybackurls"

--- a/net-misc/wireshark-sap-plugin/wireshark-sap-plugin-0.9.1.ebuild
+++ b/net-misc/wireshark-sap-plugin/wireshark-sap-plugin-0.9.1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 CMAKE_MAKEFILE_GENERATOR=emake
-inherit cmake eutils multilib
+inherit cmake multilib
 
 DESCRIPTION="Wireshark plugin for SAP's protocols"
 HOMEPAGE="https://github.com/CoreSecurity/SAP-Dissection-plug-in-for-Wireshark"

--- a/net-wireless/dump1090_sdrplus/dump1090_sdrplus-20190812.ebuild
+++ b/net-wireless/dump1090_sdrplus/dump1090_sdrplus-20190812.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-#inherit toolchain-funcs eutils
+#inherit toolchain-funcs
 
 DESCRIPTION="Mode S decoder for (SDR) devices including RTL SDR, HackRF, Airspy and SDRplay"
 HOMEPAGE="https://github.com/itemir/dump1090_sdrplus"

--- a/net-wireless/fern-wifi-cracker/fern-wifi-cracker-3.1.ebuild
+++ b/net-wireless/fern-wifi-cracker/fern-wifi-cracker-3.1.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="sqlite"
 
-inherit eutils desktop python-single-r1 xdg-utils
+inherit wrapper desktop python-single-r1 xdg-utils
 
 DESCRIPTION="Wireless tool for WEP/WPA cracking and WPS keys recovery"
 HOMEPAGE="https://github.com/savio-code/fern-wifi-cracker"

--- a/net-wireless/fern-wifi-cracker/fern-wifi-cracker-3.3.ebuild
+++ b/net-wireless/fern-wifi-cracker/fern-wifi-cracker-3.3.ebuild
@@ -6,7 +6,7 @@ EAPI=7
 PYTHON_COMPAT=( python3_{10..11} )
 PYTHON_REQ_USE="sqlite"
 
-inherit eutils desktop python-single-r1 xdg-utils
+inherit wrapper desktop python-single-r1 xdg-utils
 
 DESCRIPTION="Wireless tool for WEP/WPA cracking and WPS keys recovery"
 HOMEPAGE="https://github.com/savio-code/fern-wifi-cracker"

--- a/net-wireless/grimwepa/grimwepa-1.10_p5-r101.ebuild
+++ b/net-wireless/grimwepa/grimwepa-1.10_p5-r101.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit desktop
 
 DESCRIPTION="A password cracker for both WEP and WPA-encrypted access points"
 HOMEPAGE="http://code.google.com/p/grimwepa/"

--- a/net-wireless/grimwepa/grimwepa-1.10_p6.ebuild
+++ b/net-wireless/grimwepa/grimwepa-1.10_p6.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit eutils
+inherit desktop
 
 DESCRIPTION="A password cracker for both WEP and WPA-encrypted access points"
 HOMEPAGE="http://code.google.com/p/grimwepa/"

--- a/net-wireless/mmdvmhost/mmdvmhost-9999.ebuild
+++ b/net-wireless/mmdvmhost/mmdvmhost-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit git-r3 eutils
+inherit git-r3 epatch
 
 DESCRIPTION="The host program for MMDVM"
 HOMEPAGE="https://github.com/g4klx/MMDVMHost"

--- a/net-wireless/mmdvmhost/mmdvmhost-9999.ebuild
+++ b/net-wireless/mmdvmhost/mmdvmhost-9999.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit git-r3 epatch
+inherit git-r3
 
 DESCRIPTION="The host program for MMDVM"
 HOMEPAGE="https://github.com/g4klx/MMDVMHost"
@@ -19,7 +19,7 @@ DEPEND=""
 RDEPEND="${DEPEND}"
 
 src_prepare() {
-	use dmr-access-control || epatch "${FILESDIR}"/disable-dmr-accesscontrol.patch
+	use dmr-access-control || eapply "${FILESDIR}"/disable-dmr-accesscontrol.patch
 	sed -i -e "s#CFLAGS  = -g -O3 -Wall#CFLAGS  = ${CFLAGS}#" -e "s#LDFLAGS = -g#LDFLAGS = ${LDFLAGS}#" Makefile
 	eapply_user
 }

--- a/sys-devel/gdb-dashboard/gdb-dashboard-9999.ebuild
+++ b/sys-devel/gdb-dashboard/gdb-dashboard-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Modular visual interface for GDB in Python"
 HOMEPAGE="https://github.com/cyrus-and/gdb-dashboard"

--- a/sys-devel/peda/peda-9999.ebuild
+++ b/sys-devel/peda/peda-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=7
 
 PYTHON_COMPAT=( python3_{10..11} )
 
-inherit eutils python-single-r1
+inherit wrapper python-single-r1
 
 DESCRIPTION="Python Exploit Development Assistance for GDB"
 HOMEPAGE="https://github.com/longld/peda"

--- a/sys-kernel/compat-drivers/compat-drivers-5.10.34.ebuild
+++ b/sys-kernel/compat-drivers/compat-drivers-5.10.34.ebuild
@@ -14,7 +14,7 @@ CPD_USE_EXPAND_ethernet="alx atl1 atl1c atl1e atl2"
 # These are officially supported
 CPD_USE_EXPAND_various="i915"
 
-inherit linux-mod linux-info eutils compat-drivers-3.8-r1
+inherit linux-mod linux-info epatch compat-drivers-3.8-r1
 
 # upstream versioning, ex.: 3.7-rc1-6
 UPSTREAM_PVR="${PV//_/-}" && UPSTREAM_PVR="${UPSTREAM_PVR/-p/-}"

--- a/sys-kernel/compat-drivers/compat-drivers-5.10.34.ebuild
+++ b/sys-kernel/compat-drivers/compat-drivers-5.10.34.ebuild
@@ -14,7 +14,7 @@ CPD_USE_EXPAND_ethernet="alx atl1 atl1c atl1e atl2"
 # These are officially supported
 CPD_USE_EXPAND_various="i915"
 
-inherit linux-mod linux-info epatch compat-drivers-3.8-r1
+inherit linux-mod linux-info compat-drivers-3.8-r1
 
 # upstream versioning, ex.: 3.7-rc1-6
 UPSTREAM_PVR="${PV//_/-}" && UPSTREAM_PVR="${UPSTREAM_PVR/-p/-}"
@@ -65,12 +65,12 @@ pkg_setup() {
 src_prepare() {
 	if use pax-kernel; then
 		for gpatch in "${FILESDIR}"/3.8-grsec/*; do
-			epatch "${gpatch}"
+			eapply "${gpatch}"
 		done
 	fi
 	# upstream might want to see this
-	epatch "${FILESDIR}"/${PN}-3.8-bt_tty.patch
-	epatch "${FILESDIR}"/${PN}-3.8-ath6kl.patch
+	eapply "${FILESDIR}"/${PN}-3.8-bt_tty.patch
+	eapply "${FILESDIR}"/${PN}-3.8-ath6kl.patch
 
 	#mcgrof said prep for inclusion in compat-wireless.git but this causes issues
 	#find "${S}" -name Makefile | xargs sed -i -e 's/export CONFIG_/export CONFIG_COMPAT_/' -e 's/COMPAT_COMPAT_/COMPAT_/' -e 's/CONFIG_COMPAT_CHECK/CONFIG_CHECK/'
@@ -86,19 +86,19 @@ src_prepare() {
 		ewarn "world roaming on the device until crda provides a valid regdomain."
 		ewarn "Short version, this is not a way to break the law, this will automatically"
 		ewarn "make your card less functional unless you set a proper regdomain with iw/crda."
-		epatch "${FILESDIR}"/ath_regd_optional.patch
+		eapply "${FILESDIR}"/ath_regd_optional.patch
 	fi
 
 	if use injection; then
-		epatch "${FILESDIR}"/4002_mac80211-2.6.29-fix-tx-ctl-no-ack-retry-count.patch
-		epatch "${FILESDIR}"/4004_zd1211rw-2.6.28.patch
-	#	epatch "${FILESDIR}"/mac80211.compat08082009.wl_frag+ack_v1.patch
-	#	epatch "${FILESDIR}"/4013-runtime-enable-disable-of-mac80211-packet-injection.patch
-		epatch "${FILESDIR}"/ipw2200-inject.3.4.6.patch
+		eapply "${FILESDIR}"/4002_mac80211-2.6.29-fix-tx-ctl-no-ack-retry-count.patch
+		eapply "${FILESDIR}"/4004_zd1211rw-2.6.28.patch
+	#	eapply "${FILESDIR}"/mac80211.compat08082009.wl_frag+ack_v1.patch
+	#	eapply "${FILESDIR}"/4013-runtime-enable-disable-of-mac80211-packet-injection.patch
+		eapply "${FILESDIR}"/ipw2200-inject.3.4.6.patch
 	fi
 	if use noleds; then
 		sed -ir 's/^\(export CONFIG_.*_LEDS=\)y$/\1n/' config.mk
-		epatch "${FILESDIR}/leds-disable-strict-${PV}.patch"
+		eapply "${FILESDIR}/leds-disable-strict-${PV}.patch"
 	fi
 	use debug-driver && sed -i '/DEBUG=y/s/^# *//' "${S}"/config.mk
 	use debugfs && sed -i '/DEBUGFS/s/^# *//' "${S}"/config.mk

--- a/www-apps/beef/beef-0.5.0.0-r1.ebuild
+++ b/www-apps/beef/beef-0.5.0.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 USE_RUBY="ruby30 ruby31 ruby32"
-inherit epatch ruby-single
+inherit ruby-single
 
 #default fails, looks too complex
 RESTRICT="test"
@@ -69,7 +69,7 @@ BDEPEND="${RDEPEND}
 #S="${WORKDIR}/all/beef-${P}/"
 
 src_prepare() {
-#	epatch "${FILESDIR}/0.4.6_unbundler.patch"
+#	eapply "${FILESDIR}/0.4.6_unbundler.patch"
 #	rm {Gemfile*,.gitignore,install*,update-beef}
 	rm {.gitignore,install*,update-beef}
 	#as noted above, these are missing deps

--- a/www-apps/beef/beef-0.5.0.0-r1.ebuild
+++ b/www-apps/beef/beef-0.5.0.0-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 
 USE_RUBY="ruby30 ruby31 ruby32"
-inherit eutils ruby-single
+inherit epatch ruby-single
 
 #default fails, looks too complex
 RESTRICT="test"


### PR DESCRIPTION
Fix #1530

I also found some packages still using epatch instead of eapply and replaced that too. Accorging to the [Dev Manual](https://devmanual.gentoo.org/ebuild-writing/functions/src_prepare/epatch/index.html) there is a slight difference between epatch and eapply.

I did not test these changes.