### PR TITLE
net-analyzer/wpscan: Bump dev-ruby/cms_scanner dependency version.

### DIFF
--- a/net-analyzer/wpscan/wpscan-3.8.25.ebuild
+++ b/net-analyzer/wpscan/wpscan-3.8.25.ebuild
@@ -19,7 +19,7 @@ SLOT="0"
 
 ruby_add_bdepend "dev-ruby/bundler:2"
 ruby_add_rdepend "
-	>=dev-ruby/cms_scanner-0.13.8"
+	>=dev-ruby/cms_scanner-0.13.9"
 
 each_ruby_prepare() {
 #https://github.com/wpscanteam/wpscan/issues/1266


### PR DESCRIPTION
Upstream has bumped the dev-ruby/cms_scanner dependency to version 0.13.9: https://github.com/wpscanteam/wpscan/compare/v3.8.24...v3.8.25#diff-7563db6e4a74b7ffc1bfed662a343ca314eb8aa36fdd551154a09531d26b47c5R23

But the ebuild hasn't been updated accordingly.

Trying to build with an older version fails:

```
 * Running prepare phase for all
 * Running prepare phase for all
 * Running source copy phase for ruby31
 * Running prepare phase for ruby31
Resolving dependencies...
Could not find gem 'cms_scanner (~> 0.13.9)', which is required by gem 'wpscan', in any of the sources.

The source contains the following gems matching 'cms_scanner':
  * cms_scanner-0.13.8
```