### PR TITLE
app-forensics/libewf: fix fuse dependency

### DIFF
--- a/app-forensics/libewf/libewf-20230212.ebuild
+++ b/app-forensics/libewf/libewf-20230212.ebuild
@@ -55,7 +55,7 @@ DEPEND="
 RDEPEND="
 	${DEPEND}
 	python? ( ${PYTHON_DEPS} )
-	fuse? ( sys-fs/fuse )
+	fuse? ( sys-fs/fuse:0 )
 "
 
 src_prepare() {


### PR DESCRIPTION
 ewfmount links to libfuse.so.2, which is provided by sys-fs/fuse:0 but not by sys-fs/fuse:3. Without specifying the slot, sys-fs/fuse:3 would satisfy the dependency without providing the required lib, resulting in a build with fuse support disabled.