### PR TITLE
python bump

### DIFF
--- a/dev-python/cc2538-bsl/metadata.xml
+++ b/dev-python/cc2538-bsl/metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>sidhayn@gmail.com</email>
+		<name>Zero_Chaos</name>
+	</maintainer>
+	<stabilize-allarches/>
+	<upstream>
+		<remote-id type="pypi">cc2538-bsl</remote-id>
+		<remote-id type="github">JelmerT/cc2538-bsl</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/pentoo/pentoo-core/pentoo-core-2024.1-r2.ebuild
+++ b/pentoo/pentoo-core/pentoo-core-2024.1-r2.ebuild
@@ -55,7 +55,6 @@ PDEPEND="${PDEPEND}
 		net-misc/dhcp
 		net-misc/mosh
 		net-misc/vconfig
-		sys-apps/elfix
 		sys-apps/mlocate
 		sys-apps/usb_modeswitch
 		sys-auth/nss-mdns

--- a/pentoo/pentoo-proxies/pentoo-proxies-2024.1.ebuild
+++ b/pentoo/pentoo-proxies/pentoo-proxies-2024.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -18,7 +18,6 @@ PDEPEND="
 		net-dns/dnscrypt-proxy
 		net-misc/proxychains
 		net-proxy/3proxy
-		net-proxy/mitmproxy
 		net-proxy/privoxy
 		net-proxy/redsocks
 		net-proxy/tsocks

--- a/pentoo/zero-system/zero-system-2024.1.ebuild
+++ b/pentoo/zero-system/zero-system-2024.1.ebuild
@@ -114,7 +114,6 @@ RDEPEND="
 			net-wireless/md380tools
 			!lto? ( dev-embedded/arduino )
 			media-tv/v4l-utils
-			media-video/vidcutter
 			x11-misc/xdotool
 			)
 "

--- a/profiles/pentoo/base/package.keywords/python3_12
+++ b/profiles/pentoo/base/package.keywords/python3_12
@@ -1,0 +1,6 @@
+=app-admin/supervisor-4.2.5-r1 amd64 x86
+=x11-misc/redshift-1.12-r11 amd64 x86
+=dev-libs/libpwquality-1.4.5-r2 amd64 x86
+=dev-libs/libnl-3.9.0 amd64 x86
+=app-pda/usbmuxd-1.1.1_p20231011 amd64 x86
+=app-pda/libimobiledevice-1.3.0_p20240201 amd64 x86

--- a/profiles/pentoo/base/package.mask
+++ b/profiles/pentoo/base/package.mask
@@ -187,3 +187,6 @@ dev-lang/lua:0
 #not sure why x86 is pulling in the old version
 #forcing upgrade
 <media-libs/audacity-3.3.3
+
+#force sticky upgrade
+<app-pda/libplist-2.3

--- a/profiles/pentoo/base/packages
+++ b/profiles/pentoo/base/packages
@@ -22,7 +22,6 @@ virtual/os-headers
 sys-devel/gnuconfig
 app-arch/gzip
 net-misc/iputils
-sys-apps/elfix
 virtual/editor
 sys-apps/file
 sys-apps/busybox

--- a/profiles/pentoo/zero-system/make.defaults
+++ b/profiles/pentoo/zero-system/make.defaults
@@ -1,6 +1,6 @@
 ACCEPT_LICENSE="${ACCEPT_LICENSE} NVIDIA-CUDA android google-chrome Google-TOS baudline Intel-SDP Nero-AAC-EULA ms-teams-pre PUEL PUEL-11"
 
-USE="pentoo-extra zsh-completion -semantic-desktop"
+USE="${USE} pentoo-extra zsh-completion -semantic-desktop"
 #USE="${USE} -python_targets_python3_11"
 
 PORTAGE_GPG_DIR="/home/zero/.gnupg/"

--- a/profiles/pentoo/zero-system/make.defaults
+++ b/profiles/pentoo/zero-system/make.defaults
@@ -1,7 +1,7 @@
 ACCEPT_LICENSE="${ACCEPT_LICENSE} NVIDIA-CUDA android google-chrome Google-TOS baudline Intel-SDP Nero-AAC-EULA ms-teams-pre PUEL PUEL-11"
 
 USE="${USE} pentoo-extra zsh-completion -semantic-desktop"
-#USE="${USE} -python_targets_python3_11"
+USE="${USE} -python_targets_python3_11"
 
 PORTAGE_GPG_DIR="/home/zero/.gnupg/"
 PORTAGE_GPG_KEY="0xA5DD1427DD11F94A"

--- a/profiles/pentoo/zero-system/use.mask
+++ b/profiles/pentoo/zero-system/use.mask
@@ -1,0 +1,1 @@
+python_targets_python3_11


### PR DESCRIPTION
- zero-profile: make intent more clear
- cc2538-bsl: add missing metadata
- pentoo-core: drop elfix
- profile: drop elfix
- zero-system: drop vidcutter
- pentoo-proxies: drop mitmproxy, unmaintained in gentoo, tests fail, out of date
- profile: python 3.12 stuff
