### PR TITLE
lv2

### DIFF
--- a/profiles/pentoo/base/package.accept_keywords/dev-python
+++ b/profiles/pentoo/base/package.accept_keywords/dev-python
@@ -54,6 +54,8 @@ dev-python/pywerview
 
 ~dev-db/mongodb-5.0.26
 
+~media-libs/lv2-1.18.10-r1
+
 ############ Gentoo unstable ======================
 ~dev-python/ldap3-2.7
 ~dev-python/requests-credssp-2.0.0 ~amd64


### PR DESCRIPTION
- javatoolkit: pypax, fork and add accept keywords for python 3.12 migration
- javatoolkit: fix gentoo bugs
- pyvoronoi-1.1.0.ebuild
- lv2: make v1.18.10-r1 stable, python 3.12 support
