### PR TITLE
fix steghide install when /bin/sh is dash

### DIFF
--- a/app-crypt/steghide/steghide-0.5.1-r1.ebuild
+++ b/app-crypt/steghide/steghide-0.5.1-r1.ebuild
@@ -43,5 +43,7 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${ED}" docdir="${EPREFIX}/usr/share/doc/${PF}" install || die "emake install failed"
+	local libtool
+	[[ ${CHOST} == *-darwin* ]] && libtool=$(type -P glibtool) || libtool=$(type -P libtool)
+	emake DESTDIR="${ED}" docdir="${EPREFIX}/usr/share/doc/${PF}" LIBTOOL="${libtool}" install || die "emake install failed"
 }


### PR DESCRIPTION
When /bin/sh is symlinked to the dash shell, app-crypt/steghide compiles just fine but fails at the installation phase with the following error:
```
[...]
  /bin/sh libtool --tag=CXX   --mode=install /usr/lib/portage/python3.11/ebuild-helpers/xattr/install -c steghide '/var/tmp/portage/app-crypt/steghide-0.5.1-r1/image/usr/bin'
/bin/sh: 0: cannot open libtool: No such file
make[2]: *** [Makefile:439: install-binPROGRAMS] Error 2
[...]
```
This PR fixes it.