### PR TITLE
dev-ruby/cms_scanner: 0.13.9 relax publix_suffix dep

### DIFF
--- a/dev-ruby/cms_scanner/cms_scanner-0.13.9.ebuild
+++ b/dev-ruby/cms_scanner/cms_scanner-0.13.9.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2023 Gentoo Authors
+# Copyright 1999-2024 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,7 +19,7 @@ ruby_add_rdepend "
 	=dev-ruby/get_process_mem-0.2*
 	>=dev-ruby/nokogiri-1.11.4 <dev-ruby/nokogiri-1.16.0
 	>=dev-ruby/opt_parse_validator-1.9.5
-	>=dev-ruby/public_suffix-4.0.3:4
+	>=dev-ruby/public_suffix-4.0.3 <dev-ruby/public_suffix-5.1.0
 	>=dev-ruby/ruby-progressbar-1.10 <dev-ruby/ruby-progressbar-1.14
 	dev-ruby/typhoeus:1
 	>=dev-ruby/ethon-0.14 <dev-ruby/ethon-0.16


### PR DESCRIPTION
dev-ruby/public_suffix:4 masked in gentoo to be dropped next month.

Relax to allow 5.0.5 as only 5.1.0 and later blocked

See-also: https://github.com/wpscanteam/CMSScanner/blob/v0.13.9/cms_scanner.gemspec