### PR TITLE
profile: fix missing split-usr

### DIFF
--- a/profiles/pentoo/hardened/linux/amd64/23.0/split-usr/parent
+++ b/profiles/pentoo/hardened/linux/amd64/23.0/split-usr/parent
@@ -1,4 +1,4 @@
-gentoo:default/linux/amd64/23.0/hardened
+gentoo:default/linux/amd64/23.0/split-usr/hardened
 gentoo:targets/desktop
 pentoo:pentoo/arch/amd64
 ../../../base


### PR DESCRIPTION
profile: fix missing split-usr