### PR TITLE
update some dir locations

### DIFF
--- a/profiles/pentoo/base/make.defaults
+++ b/profiles/pentoo/base/make.defaults
@@ -57,8 +57,8 @@ BINPKG_COMPRESS_FLAGS="-c -T0 -19"
 #mgorny suggested this speeds up sync, in my testing it makes a rather large difference
 PORTAGE_RSYNC_EXTRA_OPTS="--omit-dir-times"
 
-DISTDIR="${PORTDIR}/distfiles"
-PKGDIR="${PORTDIR}/packages"
+DISTDIR="/var/cache/distfiles"
+PKGDIR="/var/cache/binpkgs"
 
 ACCEPT_LICENSE="* -@EULA intel-ucode-20180807 FraunhoferFDK Intel-SDP Nordic-5"
 


### PR DESCRIPTION
catalyst was overriding these but the profile is setting them the old
way instead of the new way.  This should affect almost no systems but
new catalyst doesn't seem to be overriding this
