### PR TITLE
bootstrap-profile: looks like zstd is required now

### DIFF
--- a/profiles/pentoo/bootstrap/package.use
+++ b/profiles/pentoo/bootstrap/package.use
@@ -1,4 +1,4 @@
-app-arch/libarchive -lz4 -zstd
+app-arch/libarchive -lz4
 app-arch/xz-utils -verify-sig
 app-arch/zstd -lz4
 app-crypt/gnupg -verify-sig


### PR DESCRIPTION
I removed zstd from libarchive to avoid a loop but it is required so
I'll have to find a different way.
