### PR TITLE
fixes for zaproxy

### DIFF
--- a/net-proxy/zaproxy/zaproxy-2.14.0.ebuild
+++ b/net-proxy/zaproxy/zaproxy-2.14.0.ebuild
@@ -94,6 +94,8 @@ src_prepare() {
 
 src_install() {
 	dodir /opt/"${PN}"
-	cp -R "${S}"/* "${D}/opt/${PN}" || die "Install failed!"
-	dosym -r "${EPREFIX}"/opt/"${PN}"/zap.sh /usr/bin/zaproxy
+	insinto /opt/"${PN}"
+	doins -r "${S}"/*
+	fperms +x /opt/"${PN}"/zap.sh
+	dosym -r /opt/"${PN}"/zap.sh /usr/bin/zaproxy
 }

--- a/net-proxy/zaproxy/zaproxy-2.14.0.ebuild
+++ b/net-proxy/zaproxy/zaproxy-2.14.0.ebuild
@@ -81,7 +81,7 @@ src_prepare() {
 		for i in "${PLUGINS[@]}"
 		do
 			arr=(${i//;/ })
-			rm "${S}"/plugin/"${arr[0]}-*.zap"
+			rm "${S}"/plugin/"${arr[0]}"-*.zap
 			cp "${DISTDIR}/${P}-${arr[0]}-${arr[1]}-${arr[2]}.zap" "${S}"/plugin/${arr[0]}-${arr[1]}-${arr[2]}.zap || die "failed to copy"
 		done
 		cp "${DISTDIR}/"${PLUGIN_HUD} "${S}"/plugin/

--- a/net-proxy/zaproxy/zaproxy-2.15.0.ebuild
+++ b/net-proxy/zaproxy/zaproxy-2.15.0.ebuild
@@ -94,6 +94,8 @@ src_prepare() {
 
 src_install() {
 	dodir /opt/"${PN}"
-	cp -R "${S}"/* "${D}/opt/${PN}" || die "Install failed!"
-	dosym -r "${EPREFIX}"/opt/"${PN}"/zap.sh /usr/bin/zaproxy
+	insinto /opt/"${PN}"
+	doins -r "${S}"/*
+	fperms +x /opt/"${PN}"/zap.sh
+	dosym -r /opt/"${PN}"/zap.sh /usr/bin/zaproxy
 }

--- a/net-proxy/zaproxy/zaproxy-2.15.0.ebuild
+++ b/net-proxy/zaproxy/zaproxy-2.15.0.ebuild
@@ -81,7 +81,7 @@ src_prepare() {
 		for i in "${PLUGINS[@]}"
 		do
 			arr=(${i//;/ })
-			rm "${S}"/plugin/"${arr[0]}-*.zap"
+			rm "${S}"/plugin/"${arr[0]}"-*.zap
 			cp "${DISTDIR}/${P}-${arr[0]}-${arr[1]}-${arr[2]}.zap" "${S}"/plugin/${arr[0]}-${arr[1]}-${arr[2]}.zap || die "failed to copy"
 		done
 		cp "${DISTDIR}/"${PLUGIN_HUD} "${S}"/plugin/


### PR DESCRIPTION
net-proxy/zaproxy was failing to install on my [Gentoo Prefix](https://wiki.gentoo.org/wiki/Project:Prefix) system. Fixed it by using the ebuild install functions instead of cp.
Also removed the explicit $EPREFIX from the dosym, since it was breaking the link on prefix systems because dosym already takes care of that stuff.

Additionally I noticed some (apparently harmless) errors on setup: a glob that wouldn't expand because it was quoted (fixed on second commit) and a reference to a variable $PLUGIN_HUD that was never assigned a value, resulting in a failed attempt to copy the $DISTDIR directory on line 87 since it evaluates to nothing. I did not touch the latter because I honestly do not fully understand the point of the whole deleting and copying back from another source thing, but I believe that line could be safely removed since the hud plugin is already present in the zap release tarball, and so are many other plugins that are removed and re-added.

IMO we could get rid of all that fetching of already shipped plugins thing, at least the hud one, but I'm assuming it is done that way to make it easier to maintain in case the default plugins change. But if you want I could clean it up further by making it only fetch the extra plugins.