### PR TITLE
drop failures

### DIFF
--- a/pentoo/pentoo-proxies/pentoo-proxies-2025.0.ebuild
+++ b/pentoo/pentoo-proxies/pentoo-proxies-2025.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -20,7 +20,6 @@ PDEPEND="
 		net-proxy/3proxy
 		net-proxy/privoxy
 		net-proxy/redsocks
-		net-proxy/tsocks
 		net-vpn/iodine
 		net-vpn/tor
 	)

--- a/pentoo/pentoo-scanner/pentoo-scanner-2025.0.ebuild
+++ b/pentoo/pentoo-scanner/pentoo-scanner-2025.0.ebuild
@@ -11,13 +11,16 @@ SLOT="0"
 LICENSE="GPL-3"
 IUSE="pentoo-full"
 
+# https://github.com/royhills/ike-scan/issues/43
+# https://github.com/royhills/ike-scan/pull/44
+# net-analyzer/ike-scan removed from pentoo-full
+# re-add with version 1.9.6
 PDEPEND="net-analyzer/nmap
 	net-analyzer/mdns-scan
 	pentoo-full? (
 		net-analyzer/enum4linux
 		net-analyzer/firewalk
 		net-analyzer/hunt
-		net-analyzer/ike-scan
 		net-analyzer/nbtscan
 		net-analyzer/nikto
 		net-analyzer/nmbscan


### PR DESCRIPTION
- **pentoo-proxies: drop tsocks https://bugs.gentoo.org/920323**
- **pentoo-scanner: drop ike-scan, fails to build**
