### PR TITLE
linkfinder: Fix #2286

### DIFF
--- a/net-misc/linkfinder/linkfinder-20191124.ebuild
+++ b/net-misc/linkfinder/linkfinder-20191124.ebuild
@@ -36,7 +36,7 @@ pkg_setup() {
 }
 
 src_install() {
-	distutils-r1_python_install
+	distutils-r1_src_install
 	python_foreach_impl python_newscript linkfinder.py linkfinder
 
 	insinto /usr/share/${PN}/


### PR DESCRIPTION
Fixes #2286

Use distutils-r1_src_install instead of distutils-r1_python_install.

distutils-r1_src_isntall invokes distutils-r1_python_install inside distutils-r1_foreach_impl.