### PR TITLE
fix old link and add metadata

### DIFF
--- a/net-mail/fakepop/fakepop-11.ebuild
+++ b/net-mail/fakepop/fakepop-11.ebuild
@@ -1,11 +1,10 @@
-# Copyright 2019-2024 Gentoo Authors
+# Copyright 2019-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 DESCRIPTION="fake pop3 server which returns the same messages to all users"
-HOMEPAGE="https://packages.debian.org/jessie/fakepop"
-#SRC_URI="http://deb.debian.org/debian/pool/main/f/fakepop/fakepop_${PV}.tar.gz"
+HOMEPAGE="https://launchpad.net/ubuntu/trusty/+package/fakepop"
 SRC_URI="http://archive.ubuntu.com/ubuntu/pool/universe/f/fakepop/fakepop_${PV}.tar.gz"
 
 S="${WORKDIR}/${PN}-10"

--- a/net-mail/fakepop/metadata.xml
+++ b/net-mail/fakepop/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>unmaintained@unmaintained.com</email>
+		<name>Unmaintained</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="launchpad">ubuntu/+source/fakepop</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/net-mail/fakepop/metadata.xml
+++ b/net-mail/fakepop/metadata.xml
@@ -6,6 +6,6 @@
 		<name>Unmaintained</name>
 	</maintainer>
 	<upstream>
-		<remote-id type="launchpad">ubuntu/+source/fakepop</remote-id>
+		<remote-id type="launchpad">ubuntu</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
#1823 has already been solved, but I update the homepage and add metadata with upstream URL. I've also updated the copyright date for 2025. I think we can closed that issue