### PR TITLE
updates20250512

### DIFF
--- a/pentoo/pentoo-system/pentoo-system-2025.1.ebuild
+++ b/pentoo/pentoo-system/pentoo-system-2025.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2024 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -19,7 +19,6 @@ PDEPEND="pentoo? ( pentoo/pentoo-core )"
 
 # Basic systems
 PDEPEND="${PDEPEND}
-	amd64? ( app-portage/unsymlink-lib )
 	qemu? ( app-emulation/virt-manager
 		!livecd-stage1? ( sys-apps/usermode-utilities ) )
 	video_cards_vmware? ( !livecd-stage1? ( app-emulation/open-vm-tools ) )

--- a/pentoo/zero-system/zero-system-2025.1.ebuild
+++ b/pentoo/zero-system/zero-system-2025.1.ebuild
@@ -110,7 +110,6 @@ RDEPEND="
 			media-video/xine-ui
 			net-wireless/hidclient
 			x11-misc/redshift
-			!arm? ( media-sound/baudline )
 			app-vim/nerdtree
 			media-sound/asunder
 			net-wireless/md380tools

--- a/profiles/pentoo/base/package.use/dev-python
+++ b/profiles/pentoo/base/package.use/dev-python
@@ -22,6 +22,7 @@ dev-python/django-constance database
 #required by mitmproxy
 app-arch/brotli python
 
+dev-python/pyside designer tools
 dev-python/pyside2 designer gui network widgets
 
 #required by httpx

--- a/profiles/pentoo/base/package.use/dev-qt
+++ b/profiles/pentoo/base/package.use/dev-qt
@@ -1,7 +1,7 @@
 dev-qt/qt5compat qml
 dev-qt/qtbase egl
 dev-qt/qtcore icu
-dev-qt/qtdeclarative -abi_x86_32
+dev-qt/qtdeclarative -abi_x86_32 qmlls
 dev-qt/qtgui gif
 dev-qt/qttools qml
 dev-qt/qtwebkit icu

--- a/profiles/pentoo/base/package.use/media-video
+++ b/profiles/pentoo/base/package.use/media-video
@@ -1,6 +1,6 @@
 media-video/vlc aalib bluray chromecast cdda cddb dvb dvd fontconfig ffmpeg libcaca mpeg mad mtp sid wxwindows aac dts a52 ogg opus flac theora oggvorbis matroska freetype xv stream httpd lua vcd cdio live x265 rtsp v4l speex postproc shout microdns dav1d -vaapi
 virtual/ffmpeg fdk gsm speex threads theora
-media-video/ffmpeg chromium speex threads gsm opus xvid theora openssl x265
+media-video/ffmpeg chromium gsm lame openssl opus speex theora threads x265 xvid
 media-video/libav speex threads gsm v4l theora
 media-video/mpv libmpv pipewire
 media-video/obs-studio imagemagick luajit pipewire -python speex v4l vlc

--- a/profiles/pentoo/base/package.use/python3_13_transition
+++ b/profiles/pentoo/base/package.use/python3_13_transition
@@ -1,0 +1,5 @@
+# some things haven't been moved to python 3_13 yet, mostly my fault -zero
+net-wireless/urh -python_targets_python3_13
+dev-embedded/libftdi python_single_target_python3_12
+app-misc/hivex python_single_target_python3_12
+app-forensics/afflib python_single_target_python3_12

--- a/profiles/pentoo/zero-system/make.defaults
+++ b/profiles/pentoo/zero-system/make.defaults
@@ -1,4 +1,4 @@
-ACCEPT_LICENSE="${ACCEPT_LICENSE} NVIDIA-CUDA android google-chrome Google-TOS baudline Intel-SDP Nero-AAC-EULA ms-teams-pre PUEL PUEL-11"
+ACCEPT_LICENSE="${ACCEPT_LICENSE} NVIDIA-CUDA android google-chrome Google-TOS Intel-SDP Nero-AAC-EULA ms-teams-pre PUEL PUEL-11"
 
 USE="${USE} pentoo-extra zsh-completion -semantic-desktop"
 

--- a/profiles/pentoo/zero-system/package.accept_keywords/sys-power
+++ b/profiles/pentoo/zero-system/package.accept_keywords/sys-power
@@ -1,1 +1,2 @@
 sys-power/cpufreqd
+~sys-power/nut-2.8.3


### PR DESCRIPTION
- **pentoo-system: drop unsymlink-lib**
- **zero-system: drop baudline**
- **zero-profile: drop baudline**
- **zero-profile: newer sys-power/nut for python 3.13**
- **profile: minor use updates**
- **profile: add some python 3_13 transitional stuff for a short time**
