### PR TITLE
make-pdf: remove python 3.14

### DIFF
--- a/app-forensics/make-pdf/make-pdf-0.1.7-r1.ebuild
+++ b/app-forensics/make-pdf/make-pdf-0.1.7-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{11..14} )
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit python-r1 unpacker
 


### PR DESCRIPTION
 * ERROR: app-forensics/make-pdf-0.1.7-r1::pentoo failed (depend phase):
 *   Invalid implementation in PYTHON_COMPAT: python3_14
 *
 * Call stack:
 *                  ebuild.sh, line 625:  Called source '/var/db/repos/pentoo/app-forensics/make-pdf/make-pdf-0.1.7-r1.ebuild'
 *   make-pdf-0.1.7-r1.ebuild, line   8:  Called inherit 'python-r1' 'unpacker'
 *                  ebuild.sh, line 310:  Called __qa_source '/var/db/repos/gentoo/eclass/python-r1.eclass'
 *                  ebuild.sh, line 123:  Called source '/var/db/repos/gentoo/eclass/python-r1.eclass'
 *           python-r1.eclass, line 232:  Called _python_set_globals
 *           python-r1.eclass, line 186:  Called _python_set_impls
 *     python-utils-r1.eclass, line 151:  Called die
 * The specific snippet of code:
 *   						die "Invalid implementation in PYTHON_COMPAT: ${i}"
 *
 * If you need support, post the output of `emerge --info '=app-forensics/make-pdf-0.1.7-r1::pentoo'`,
 * the complete build log and the output of `emerge -pqv '=app-forensics/make-pdf-0.1.7-r1::pentoo'`.
 * Working directory: '/usr/lib/python3.13/site-packages'
 * S: '/var/tmp/portage/app-forensics/make-pdf-0.1.7-r1/work/make-pdf-0.1.7'
