### PR TITLE
pydub: fix test

### DIFF
--- a/dev-python/pydub/pydub-0.25.1.ebuild
+++ b/dev-python/pydub/pydub-0.25.1.ebuild
@@ -28,12 +28,13 @@ BDEPEND="
 	test? (
 		media-video/ffmpeg[lame,vorbis]
 	)
-	"
+"
 
 distutils_enable_tests unittest
 
-python_test() {
-	eunittest test/
+src_prepare() {
+	use test && sed -i -e "s/Equals/Equal/" "test/test.py"
+	eapply_user
 }
 
 pkg_postinst() {


### PR DESCRIPTION
the patch can be removed when a new version with [this PR](https://github.com/jiaaro/pydub/pull/744) or [this PR](https://github.com/jiaaro/pydub/pull/769) will be out.

I've tested the ebuild with `ebuild pydub-0.25.1.ebuild clean test`, it works without the python_test function (113 tests passed).

The issue #1751 can be closed