### PR TITLE
aiomultiprocess switched from setuptools to flit

### DIFF
--- a/dev-python/aiomultiprocess/aiomultiprocess-0.9.0.ebuild
+++ b/dev-python/aiomultiprocess/aiomultiprocess-0.9.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-DISTUTILS_USE_PEP517=setuptools
+DISTUTILS_USE_PEP517=flit
 PYTHON_COMPAT=( python3_{11..13} )
 inherit distutils-r1
 


### PR DESCRIPTION
sorry for the pr spam, commit should be verified now.

should fix issue [2449](https://github.com/pentoo/pentoo-overlay/issues/2449)