### PR TITLE
pentoo-core: remove mirrorselect

### DIFF
--- a/pentoo/pentoo-core/pentoo-core-2025.2.ebuild
+++ b/pentoo/pentoo-core/pentoo-core-2025.2.ebuild
@@ -43,7 +43,6 @@ PDEPEND="${PDEPEND}
 	!pentoo-minimal? (
 		app-misc/screen
 		app-portage/eix
-		app-portage/mirrorselect
 		app-portage/portage-utils
 		app-shells/bash-completion
 		media-fonts/fira-code


### PR DESCRIPTION
we don't use it right now, and it's failing to build in docker for some
reason
