### PR TITLE
dev-util/ghidra: fixed incorrectly set permissions causing errors for…

### DIFF
--- a/dev-util/ghidra/ghidra-11.3.2.ebuild
+++ b/dev-util/ghidra/ghidra-11.3.2.ebuild
@@ -184,6 +184,7 @@ src_install() {
 	fperms +x /usr/share/ghidra/support/launch.sh
 	fperms +x /usr/share/ghidra/GPL/DemanglerGnu/os/linux_x86_64/demangler_gnu_v2_41
 	fperms +x /usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64/decompile
+	fperms +x /usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
 
 	dosym -r /usr/share/ghidra/ghidraRun /usr/bin/ghidra
 

--- a/dev-util/ghidra/ghidra-11.4-r1.ebuild
+++ b/dev-util/ghidra/ghidra-11.4-r1.ebuild
@@ -191,6 +191,7 @@ src_install() {
 	fperms +x /usr/share/ghidra/support/launch.sh
 	fperms +x /usr/share/ghidra/GPL/DemanglerGnu/os/linux_x86_64/demangler_gnu_v2_41
 	fperms +x /usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64/decompile
+	fperms +x /usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
 
 	dosym -r /usr/share/ghidra/ghidraRun /usr/bin/ghidra
 

--- a/dev-util/ghidra/ghidra-11.4.ebuild
+++ b/dev-util/ghidra/ghidra-11.4.ebuild
@@ -186,6 +186,7 @@ src_install() {
 	fperms +x /usr/share/ghidra/support/launch.sh
 	fperms +x /usr/share/ghidra/GPL/DemanglerGnu/os/linux_x86_64/demangler_gnu_v2_41
 	fperms +x /usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64/decompile
+	fperms +x /usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
 
 	dosym -r /usr/share/ghidra/ghidraRun /usr/bin/ghidra
 


### PR DESCRIPTION
I encountered this error while trying to start a ghidra debugger with gdb on
some C binary I was working on, but when I was working on ghidra on other
distros (NixOS, Debian, Kali...) I never encountered it.

<img width="1914" height="1080" alt="ghidra_pentoo_issue" src="https://github.com/user-attachments/assets/5fa7ecbc-406b-4e97-939e-f74d45d6d58b" />

Going through the directories to `/usr/share/ghidra/Ghidra/Debug/Debugger-agent-gdb/data/debugger-launchers`
I've found that these files weren't executable because the permission was
not set for them to be executable, upon fixing it with `chmod +x *`
everything was working propertly, except that the .ps1 files didnt need
the executable permission.

After this I went and checked if this was an issue with ghidra itself by compiling it
and in the master branch (12.0) the permissions were set correctly upon building,
I've also thought that this could mean that other .sh files didn't have the right
properties after my fix.

```bash
ghidra/Ghidra/Debug
$ find . | grep '\.sh$' | xargs -I {} ls -lha {}
-rw-r--r-- 1 root root 1.2K Jul 30 18:28 ./Debugger-agent-drgn/data/debugger-launchers/local-drgn.sh
-rw-r--r-- 1 root root 1.1K Jul 30 18:28 ./Debugger-agent-drgn/data/debugger-launchers/core-drgn.sh
-rw-r--r-- 1 root root 1012 Jul 30 18:28 ./Debugger-agent-drgn/data/debugger-launchers/kernel-drgn.sh
-rw-r--r-- 1 root root 1.9K Jul 30 18:28 ./Debugger-agent-lldb/data/debugger-launchers/remote-lldb.sh
-rw-r--r-- 1 root root 1.9K Jul 30 18:28 ./Debugger-agent-lldb/data/debugger-launchers/local-lldb.sh
-rw-r--r-- 1 root root 2.1K Jul 30 18:28 ./Debugger-agent-lldb/data/debugger-launchers/android-lldb.sh
-rw-r--r-- 1 root root 4.0K Jul 30 18:28 ./Debugger-agent-lldb/data/debugger-launchers/ssh-lldb.sh
-rw-r--r-- 1 root root 1.7K Jul 30 18:28 ./Debugger-agent-lldb/data/debugger-launchers/kernel-lldb.sh
-rw-r--r-- 1 root root 3.1K Jul 30 18:28 ./Debugger-agent-lldb/data/support/lldbsetuputils.sh
-rw-r--r-- 1 root root 1.7K Jul 30 18:28 ./Debugger-rmi-trace/data/debugger-launchers/raw-python3.sh
-rw-r--r-- 1 root root 3.2K Jul 30 18:28 ./Debugger-rmi-trace/data/support/setuputils.sh
-rwxr-xr-x 1 root root 2.7K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/ssh-gdbserver.sh
-rwxr-xr-x 1 root root 2.0K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/local-gdb.sh
-rwxr-xr-x 1 root root 2.8K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/qemu-sys-gdb.sh
-rwxr-xr-x 1 root root 2.0K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/wine-gdb.sh
-rwxr-xr-x 1 root root 2.2K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/local-rr.sh
-rwxr-xr-x 1 root root 4.0K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/ssh-gdb.sh
-rwxr-xr-x 1 root root 2.1K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/remote-gdb.sh
-rwxr-xr-x 1 root root 2.9K Jul 30 18:28 ./Debugger-agent-gdb/data/debugger-launchers/qemu-gdb.sh
-rw-r--r-- 1 root root 3.2K Jul 30 18:28 ./Debugger-agent-gdb/data/support/gdbsetuputils.sh
```

So the correct regex to get all of these is
`/usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh`

Applying the patch with the new regex and building it myself with ebuild merge, all was well.
