### PR TITLE
README: `emerge --sync` to `emaint sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pentoo is a Live CD and Live USB designed for penetration testing and security a
 Update the portage to the latest version
 
 ```
-emerge --sync
+emaint sync
 ```
 
 Make sure that eselect-repository and git are installed


### PR DESCRIPTION
Because of deprecation

> Primary control of all sync operations has been moved from `emerge` to `emaint`. `emerge --sync` now runs the emaint sync module with the` --auto` option

See https://wiki.gentoo.org/wiki/Project:Portage/Sync#Operation