### PR TITLE
dev-util/ghidra-11.4.2: fix fperms glob expansion

### DIFF
--- a/dev-util/ghidra/ghidra-11.4.2.ebuild
+++ b/dev-util/ghidra/ghidra-11.4.2.ebuild
@@ -191,7 +191,9 @@ src_install() {
 	fperms +x /usr/share/ghidra/support/launch.sh
 	fperms +x /usr/share/ghidra/GPL/DemanglerGnu/os/linux_x86_64/demangler_gnu_v2_41
 	fperms +x /usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64/decompile
+	shopt -s nullglob
 	fperms +x /usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
+	shopt -u nullglob
 
 	dosym -r /usr/share/ghidra/ghidraRun /usr/bin/ghidra
 


### PR DESCRIPTION
During the install phase, the ebuild called fperms on globs under
Ghidra/Debug/Debugger-*/data/{support,debugger-launchers}. If no files matched, the glob was passed literally to chmod and the build failed.

Added nullglob  so only existing *.sh scripts are passed to fperms.
Without this fix, dev-util/ghidra-11.4.2 fails to install with:

`chmod: cannot access '/var/tmp/portage/dev-util/ghidra-11.4.2/image/usr/share/ghidra/Ghidra/Debug/Debugger-*/data/support/*.sh': No such file or directory`

Tested locally, build and install now succeed.