### PR TITLE
Fix invalid glob in fperms

### DIFF
--- a/dev-util/ghidra/ghidra-11.3.2.ebuild
+++ b/dev-util/ghidra/ghidra-11.3.2.ebuild
@@ -184,7 +184,7 @@ src_install() {
 	fperms +x /usr/share/ghidra/support/launch.sh
 	fperms +x /usr/share/ghidra/GPL/DemanglerGnu/os/linux_x86_64/demangler_gnu_v2_41
 	fperms +x /usr/share/ghidra/Ghidra/Features/Decompiler/os/linux_x86_64/decompile
-	fperms +x /usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
+	chmod +x ${D}/usr/share/ghidra/Ghidra/Debug/Debugger-*/data/{debugger-launchers,support}/*.sh
 
 	dosym -r /usr/share/ghidra/ghidraRun /usr/bin/ghidra
 


### PR DESCRIPTION
Globs won't typically work with fperms upon first install of a package because the target files can't be globbed since they don't exist in real `/usr` yet. Globbing into the actual image folder fixes the issue.