### PR TITLE
updates20260415

### DIFF
--- a/pentoo/pentoo-forging/pentoo-forging-2026.1.ebuild
+++ b/pentoo/pentoo-forging/pentoo-forging-2026.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2025 Gentoo Foundation
+# Copyright 1999-2026 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
@@ -21,7 +21,6 @@ PDEPEND="
 	pentoo-extra? (
 		net-analyzer/gspoof
 		net-analyzer/isic
-		net-analyzer/packit
 		net-analyzer/rain
 	)
 "

--- a/pentoo/pentoo-forging/pentoo-forging-2026.1.ebuild
+++ b/pentoo/pentoo-forging/pentoo-forging-2026.1.ebuild
@@ -6,10 +6,10 @@ EAPI=8
 DESCRIPTION="Pentoo forging meta ebuild"
 HOMEPAGE="https://www.pentoo.org"
 
-SLOT="0"
 LICENSE="GPL-3"
-IUSE="pentoo-extra pentoo-full"
+SLOT="0"
 KEYWORDS="~amd64 ~arm ~x86"
+IUSE="pentoo-extra pentoo-full"
 
 PDEPEND="
 	net-analyzer/hping

--- a/pentoo/zero-system/zero-system-2026.1-r1.ebuild
+++ b/pentoo/zero-system/zero-system-2026.1-r1.ebuild
@@ -13,7 +13,7 @@ KEYWORDS="amd64 arm x86"
 IUSE="dev desktop minimal nu printer"
 
 RDEPEND="
-	app-admin/keepassxc
+	app-admin/keepass
 	app-shells/zsh
 	net-misc/keychain
 	sys-auth/ykpers

--- a/pentoo/zero-system/zero-system-2026.1-r1.ebuild
+++ b/pentoo/zero-system/zero-system-2026.1-r1.ebuild
@@ -48,7 +48,6 @@ RDEPEND="
 			app-vim/nerdtree
 			dev-python/mock
 			dev-python/pytest
-			dev-ruby/blinkstick
 			dev-ruby/bundler-audit
 			dev-ruby/irb
 			dev-ruby/pry

--- a/profiles/pentoo/base/profile.bashrc
+++ b/profiles/pentoo/base/profile.bashrc
@@ -65,6 +65,10 @@ if [[ ${CATEGORY}/${PN} == dev-qt/qtnetwork ]]; then
   # zero uses extra warnings to find bugs
   export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"
 fi
+if [[ ${CATEGORY}/${PN} == app-text/qpdf ]]; then
+  # zero uses extra warnings to find bugs
+  export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"
+fi
 if [[ ${CATEGORY}/${PN} == dev-qt/qtshadertools ]]; then
   # zero uses extra warnings to find bugs
   export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"

--- a/profiles/pentoo/base/profile.bashrc
+++ b/profiles/pentoo/base/profile.bashrc
@@ -65,6 +65,10 @@ if [[ ${CATEGORY}/${PN} == dev-qt/qtnetwork ]]; then
   # zero uses extra warnings to find bugs
   export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"
 fi
+if [[ ${CATEGORY}/${PN} == app-forensics/sleuthkit ]]; then
+  # zero uses extra warnings to find bugs
+  export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"
+fi
 if [[ ${CATEGORY}/${PN} == app-text/qpdf ]]; then
   # zero uses extra warnings to find bugs
   export CXXFLAGS="${CXXFLAGS/-Werror=stringop-overread/}"


### PR DESCRIPTION
- **zero-system: gentoo masked keepassxc so I guess I'll try keepass**
- **zero-system: drop blinkstick**
- **profile: ease up zero's error finding**
- **profile: ease up zero's error finding**
- **pentoo/pentoo-forging: add 2026.1, drop 2025.2**
- **pentoo/pentoo-forging: reorder variables**
