### PR TITLE
radare2-6.1.6: Updated fix-riscv-cs-mode patch

### DIFF
--- a/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
+++ b/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
@@ -1,0 +1,12 @@
+--- a/libr/arch/p/riscv_cs/plugin.c
++++ b/libr/arch/p/riscv_cs/plugin.c
+@@ -259,7 +259,7 @@
+ }
+ 
+ #define CSINC RISCV
+-#if CS_NEXT_VERSION >= 6
++#ifdef CS_VERSION_PRE_RELEASE
+ #define CSINC_MODE (CS_MODE_RISCV_C | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
+ #else
+ #define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
+ #endif

--- a/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
+++ b/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
@@ -5,7 +5,7 @@
  
  #define CSINC RISCV
 -#if CS_NEXT_VERSION >= 6
-+#ifdef CS_VERSION_PRE_RELEASE
++#if defined(CS_VERSION_PRE_RELEASE) && CS_VERSION_PRE_RELEASE != CS_VERSION_STABLE
  #define CSINC_MODE (CS_MODE_RISCV_C | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
  #else
  #define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))

--- a/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
+++ b/dev-util/radare2/files/radare2-6.1.6-fix-riscv-cs-mode.patch
@@ -1,12 +1,24 @@
 --- a/libr/arch/p/riscv_cs/plugin.c
 +++ b/libr/arch/p/riscv_cs/plugin.c
-@@ -259,7 +259,7 @@
+@@ -2,6 +2,11 @@
+ 
+ #include <r_arch.h>
+ 
++/* Forward+backward compat: CS_MODE_RISCVC -> CS_MODE_RISCV_C rename.
++ * #if can't pick the right name (identical macros across alpha6/7),
++ * so we pre-rename the enum before including capstone.h.
++ * ideally remove when capstone 6 gets fully released. */
++#define CS_MODE_RISCVC CS_MODE_RISCV_C
+ #include <capstone/capstone.h>
+ #if CS_API_MAJOR >= 5
+ #include <capstone/riscv.h>
+@@ -259,11 +264,7 @@
  }
  
  #define CSINC RISCV
 -#if CS_NEXT_VERSION >= 6
-+#if defined(CS_VERSION_PRE_RELEASE) && CS_VERSION_PRE_RELEASE != CS_VERSION_STABLE
  #define CSINC_MODE (CS_MODE_RISCV_C | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
- #else
- #define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
- #endif
+-#else
+-#define CSINC_MODE (CS_MODE_RISCVC | ((as->config->bits == 64)? CS_MODE_RISCV64: CS_MODE_RISCV32))
+-#endif
+ #include "../capstone.inc.c"

--- a/dev-util/radare2/radare2-6.1.6.ebuild
+++ b/dev-util/radare2/radare2-6.1.6.ebuild
@@ -49,7 +49,8 @@ BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}/${PN}-5.8.4-test.patch"
-)
+	"${FILESDIR}/${PN}-6.1.6-fix-riscv-cs-mode.patch"
+) # IMPORTANT: remove the riscv patch above on next version bump (should be fixed upstream)
 
 src_prepare() {
 	default
@@ -65,6 +66,7 @@ src_prepare() {
 	# Fix hardcoded docdir for fortunes
 	sed -i -e "/^#define R2_FORTUNES/s/radare2/$PF/" \
 		libr/include/r_userconf.h.acr || die
+
 }
 
 src_configure() {


### PR DESCRIPTION
Better fix for #2856.

I found an edge case in the current `radare2-6.1.6-fix-riscv-cs-mode.patch`. The `#if defined(CS_VERSION_PRE_RELEASE)` guard works on alpha7 but fails on alpha4 through alpha6 of capstone 6.0.0. 

Those versions have the same macros as alpha7 (`CS_API_MAJOR=6`, `CS_NEXT_VERSION=7`, no `CS_VERSION_PRE_RELEASE`) but still use the old enum name `CS_MODE_RISCVC`.

The fix replaces the whole `#if`/`#else`/`#endif` block with a single `#define` before the capstone include:

```c
#define CS_MODE_RISCVC CS_MODE_RISCV_C
#include <capstone/capstone.h>
```

It fixes all versions both backwards and forwards for now, for version with the incorrect enum it does the fix, and for ones with the correct enum it's just a noop.

I tested against all six capstone versions (5.0.7, alpha4 through alpha7, next). The define passes every one while the `CS_VERSION_PRE_RELEASE` guard fails on alpha7.