### PR TITLE
dev-python/grpcio-tools: fix protobuf dependency version

### DIFF
--- a/dev-python/grpcio-tools/grpcio-tools-1.82.1-r1.ebuild
+++ b/dev-python/grpcio-tools/grpcio-tools-1.82.1-r1.ebuild
@@ -18,8 +18,8 @@ KEYWORDS="~amd64 ~arm64 ~x86"
 
 RDEPEND="
 	=dev-python/grpcio-$(ver_cut 1-2 ${PV})*[${PYTHON_USEDEP}]
-	>=dev-python/protobuf-6.33.5[${PYTHON_USEDEP}]
-	<dev-python/protobuf-7[${PYTHON_USEDEP}]
+	>=dev-python/protobuf-7.35.1[${PYTHON_USEDEP}]
+	<dev-python/protobuf-8[${PYTHON_USEDEP}]
 "
 
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
grpcio-tools 1.82.1 bundles libprotoc 35.0. It generates code for protobuf 7.35. However, the ebuild requires protobuf >=6.33.5 and <7. With protobuf 6.x the generated stubs do not import. They raise google.protobuf.runtime_version.VersionError. This also breaks opensnitch-ui.

Upstream requires protobuf >=7.35.1 and <8 (see Requires-Dist). Set the same range here.