### PR TITLE
dev-libs/hashdb: fix CFLAGS override and broken test

### DIFF
--- a/dev-libs/hashdb/files/hashdb-3.1.0-cstdint.patch
+++ b/dev-libs/hashdb/files/hashdb-3.1.0-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/src_libhashdb/hasher/file_reader_helper.hpp
++++ b/src_libhashdb/hasher/file_reader_helper.hpp
+@@ -32,6 +32,7 @@
+
+ #include <sys/stat.h>
+ #include <fcntl.h>
++#include <cstdint>
+ #include "filename_t.hpp"
+
+ // if pread64 is not defined then define it in the global namespace

--- a/dev-libs/hashdb/hashdb-3.1.0-r3.ebuild
+++ b/dev-libs/hashdb/hashdb-3.1.0-r3.ebuild
@@ -36,6 +36,7 @@ pkg_setup() {
 
 src_prepare() {
 	eapply "${FILESDIR}"/fix_undefined_reference_to_libewf_handle_read_random.patch
+	eapply "${FILESDIR}"/hashdb-3.1.0-cstdint.patch
 
 	# https://github.com/NPS-DEEP/hashdb/issues/6
 	if has_version ">=dev-libs/openssl-1.1.0"; then

--- a/dev-libs/hashdb/hashdb-3.1.0-r3.ebuild
+++ b/dev-libs/hashdb/hashdb-3.1.0-r3.ebuild
@@ -1,0 +1,70 @@
+# Copyright 1999-2024 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+PYTHON_COMPAT=( python3_{12..14} )
+
+inherit autotools flag-o-matic python-single-r1
+
+DESCRIPTION="The hashdb block hash database tool and API"
+HOMEPAGE="https://github.com/NPS-DEEP/hashdb"
+SRC_URI="https://github.com/NPS-DEEP/hashdb/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+KEYWORDS="amd64 ~arm64 ~x86"
+LICENSE="GPL-3 public-domain"
+SLOT="0"
+
+IUSE="python static-libs test"
+REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	app-forensics/libewf
+	dev-libs/icu
+	dev-libs/openssl:0=
+	python? ( ${PYTHON_DEPS} )
+	sys-libs/zlib"
+
+DEPEND="${RDEPEND}
+	python? ( dev-lang/swig )
+	dev-build/libtool"
+
+pkg_setup() {
+	python-single-r1_pkg_setup
+}
+
+src_prepare() {
+	eapply "${FILESDIR}"/fix_undefined_reference_to_libewf_handle_read_random.patch
+
+	# https://github.com/NPS-DEEP/hashdb/issues/6
+	if has_version ">=dev-libs/openssl-1.1.0"; then
+		eapply "${FILESDIR}"/fix_configure_openssl-1.1.0_detection.patch
+	fi
+
+	python_fix_shebang "${S}"
+
+	eautoreconf
+	default
+}
+
+src_configure() {
+	append-cxxflags -std=c++11
+	econf \
+		--without-o3 \
+		$(use_enable python SWIG_Python) \
+		$(use_enable static-libs static)
+}
+
+src_test() {
+	emake -j1 check
+}
+
+src_install() {
+	default
+	find "${D}" -name '*.la' -delete || die
+
+	if use python && ! use static-libs; then
+		rm -f "${D}$(python_get_sitedir)"/*.a || die
+	fi
+}


### PR DESCRIPTION
## Summary

- Pass `--without-o3` to `econf` to prevent `configure.ac` from adding `-g` and upgrading `-O2` to `-O3`, overriding user CFLAGS (fixes #1458)
- Remove `memory_analysis.sh` from `src_test`: it requires `hashdb` to be installed in PATH during the test phase, which it is not; unit tests via `emake check` still run (fixes #820)
- Drop `dev-debug/valgrind` and `dev-python/matplotlib` from test `DEPEND` — only needed by the removed script

## Test plan

- [ ] `emerge -v dev-libs/hashdb` builds cleanly without CFLAGS warnings
- [ ] `emerge -v dev-libs/hashdb USE="test"` runs unit tests successfully